### PR TITLE
feat: examples, landing page, and RubyGems publish prep

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: [docs/**]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,488 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ruby-mana 🔮 — Embed LLM as Native Ruby</title>
+  <meta name="description" content="Write natural language in Ruby that reads and writes variables, calls functions, and controls program flow. LLM as a first-class language construct.">
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --text-dim: #8b949e;
+      --accent: #a371f7;
+      --accent2: #f778ba;
+      --accent3: #79c0ff;
+      --code-bg: #0d1117;
+      --green: #3fb950;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      overflow-x: hidden;
+    }
+
+    .container { max-width: 900px; margin: 0 auto; padding: 0 24px; }
+
+    /* Hero */
+    .hero {
+      text-align: center;
+      padding: 80px 0 60px;
+      position: relative;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      top: -200px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 600px;
+      height: 600px;
+      background: radial-gradient(circle, rgba(163,113,247,0.15) 0%, transparent 70%);
+      pointer-events: none;
+    }
+
+    .hero h1 {
+      font-size: 3.5rem;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      margin-bottom: 16px;
+    }
+
+    .hero h1 .emoji { font-size: 3rem; }
+    .hero h1 .mana { color: var(--accent); }
+
+    .hero .tagline {
+      font-size: 1.25rem;
+      color: var(--text-dim);
+      max-width: 500px;
+      margin: 0 auto 40px;
+    }
+
+    .hero-code {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 24px 32px;
+      text-align: left;
+      display: inline-block;
+      max-width: 600px;
+      width: 100%;
+      font-size: 0.95rem;
+    }
+
+    /* Install bar */
+    .install {
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      margin-top: 32px;
+      flex-wrap: wrap;
+    }
+
+    .install code {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px 20px;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.9rem;
+      color: var(--green);
+    }
+
+    .btn {
+      display: inline-block;
+      padding: 10px 24px;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .btn-primary:hover { opacity: 0.85; }
+
+    .btn-secondary {
+      background: var(--surface);
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+
+    .btn-secondary:hover { border-color: var(--accent); }
+
+    /* Sections */
+    section {
+      padding: 60px 0;
+      border-top: 1px solid var(--border);
+    }
+
+    section h2 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 12px;
+      letter-spacing: -0.02em;
+    }
+
+    section h2 .dim { color: var(--text-dim); font-weight: 400; }
+
+    section p.lead {
+      color: var(--text-dim);
+      font-size: 1.05rem;
+      margin-bottom: 32px;
+      max-width: 600px;
+    }
+
+    /* Code blocks */
+    pre {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 20px 24px;
+      overflow-x: auto;
+      margin-bottom: 24px;
+      font-size: 0.88rem;
+      line-height: 1.7;
+    }
+
+    code {
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    }
+
+    .code-label {
+      font-size: 0.75rem;
+      color: var(--text-dim);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 8px;
+    }
+
+    /* Syntax colors */
+    .kw { color: #ff7b72; }
+    .str { color: #a5d6ff; }
+    .mana-str { color: #f0abfc; background: rgba(163,113,247,0.1); border-radius: 3px; padding: 0 2px; }
+    .cmt { color: #8b949e; font-style: italic; }
+    .num { color: #79c0ff; }
+    .fn { color: #d2a8ff; }
+    .var { color: #ffa657; }
+    .sym { color: #7ee787; }
+    .op { color: #ff7b72; }
+
+    /* Feature grid */
+    .features {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 20px;
+      margin-top: 32px;
+    }
+
+    .feature {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 24px;
+    }
+
+    .feature .icon { font-size: 1.5rem; margin-bottom: 8px; }
+    .feature h3 { font-size: 1rem; margin-bottom: 6px; }
+    .feature p { color: var(--text-dim); font-size: 0.88rem; }
+
+    /* How it works */
+    .steps {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      margin-top: 24px;
+    }
+
+    .step {
+      display: flex;
+      gap: 16px;
+      align-items: flex-start;
+    }
+
+    .step-num {
+      flex-shrink: 0;
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      background: var(--accent);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 0.85rem;
+    }
+
+    .step-text { padding-top: 4px; }
+    .step-text strong { color: var(--text); }
+    .step-text span { color: var(--text-dim); font-size: 0.9rem; }
+
+    /* Comparison */
+    .comparison {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
+      margin-top: 24px;
+    }
+
+    .comparison > div {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 20px;
+    }
+
+    .comparison h3 {
+      font-size: 0.85rem;
+      color: var(--text-dim);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 12px;
+    }
+
+    .comparison pre {
+      margin: 0;
+      border: none;
+      background: var(--code-bg);
+      font-size: 0.82rem;
+    }
+
+    /* Footer */
+    footer {
+      padding: 40px 0;
+      border-top: 1px solid var(--border);
+      text-align: center;
+      color: var(--text-dim);
+      font-size: 0.85rem;
+    }
+
+    footer a { color: var(--accent); text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+
+    /* Responsive */
+    @media (max-width: 640px) {
+      .hero h1 { font-size: 2.2rem; }
+      .hero .tagline { font-size: 1rem; }
+      .comparison { grid-template-columns: 1fr; }
+      .hero-code { padding: 16px 20px; font-size: 0.85rem; }
+    }
+  </style>
+</head>
+<body>
+
+<div class="container">
+  <!-- Hero -->
+  <div class="hero">
+    <h1><span class="mana">ruby-mana</span> <span class="emoji">🔮</span></h1>
+    <p class="tagline">Embed LLM as native Ruby. Write natural language, it just runs.</p>
+
+    <div class="hero-code">
+<pre style="margin:0;border:none;padding:0;background:none;"><span class="kw">require</span> <span class="str">"mana"</span>
+
+numbers = [<span class="num">1</span>, <span class="str">"2"</span>, <span class="str">"three"</span>, <span class="str">"cuatro"</span>, <span class="str">"五"</span>]
+<span class="mana-str">~"算 &lt;numbers&gt; 的语义平均值存 &lt;result&gt;"</span>
+<span class="fn">puts</span> result  <span class="cmt"># =&gt; 3.0</span></pre>
+    </div>
+
+    <div class="install">
+      <code>gem install ruby-mana</code>
+      <a href="https://github.com/carlnoah6/ruby-mana" class="btn btn-primary">GitHub →</a>
+      <a href="https://rubygems.org/gems/ruby-mana" class="btn btn-secondary">RubyGems</a>
+    </div>
+  </div>
+
+  <!-- What makes it different -->
+  <section>
+    <h2>Not a wrapper. <span class="dim">A language construct.</span></h2>
+    <p class="lead">Most LLM libraries give you an API client. Mana gives you a new kind of string — one that executes.</p>
+
+    <div class="features">
+      <div class="feature">
+        <div class="icon">🔗</div>
+        <h3>Bidirectional binding</h3>
+        <p>LLM reads and writes your Ruby variables directly. No serialization, no parsing output.</p>
+      </div>
+      <div class="feature">
+        <div class="icon">🔄</div>
+        <h3>Loops & function calls</h3>
+        <p>LLM can iterate over collections and call your Ruby methods — with real return values.</p>
+      </div>
+      <div class="feature">
+        <div class="icon">✨</div>
+        <h3>Minimal syntax</h3>
+        <p><code>~"..."</code> in .rb files. Bare strings in .nrb files. That's it.</p>
+      </div>
+      <div class="feature">
+        <div class="icon">🧬</div>
+        <h3>Effect system</h3>
+        <p>Built on algebraic effects — Fiber-based handler loop with tool-use protocol.</p>
+      </div>
+      <div class="feature">
+        <div class="icon">🎯</div>
+        <h3>Object manipulation</h3>
+        <p>Read attributes, write attributes, work with any Ruby object — Structs, classes, OpenStruct.</p>
+      </div>
+      <div class="feature">
+        <div class="icon">🌐</div>
+        <h3>Multilingual</h3>
+        <p>Prompts work in any language. Write Chinese, English, Spanish — the LLM understands.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Examples -->
+  <section>
+    <h2>See it in action</h2>
+
+    <div class="code-label">Object manipulation</div>
+<pre><span class="kw">class</span> <span class="fn">Email</span>
+  <span class="fn">attr_accessor</span> <span class="sym">:subject</span>, <span class="sym">:body</span>, <span class="sym">:category</span>, <span class="sym">:priority</span>
+<span class="kw">end</span>
+
+email = <span class="fn">Email</span>.<span class="fn">new</span>
+email.subject = <span class="str">"URGENT: Server down"</span>
+email.body = <span class="str">"Database connection pool exhausted..."</span>
+
+<span class="mana-str">~"读 &lt;email&gt; 的 subject 和 body，设 category 和 priority"</span>
+
+<span class="fn">puts</span> email.category  <span class="cmt"># =&gt; "urgent"</span>
+<span class="fn">puts</span> email.priority  <span class="cmt"># =&gt; "high"</span></pre>
+
+    <div class="code-label">Loops & function calls</div>
+<pre><span class="kw">def</span> <span class="fn">fetch_price</span>(symbol)
+  { <span class="str">"AAPL"</span> =&gt; <span class="num">189.5</span>, <span class="str">"GOOG"</span> =&gt; <span class="num">141.2</span>, <span class="str">"TSLA"</span> =&gt; <span class="num">248.9</span> }[symbol] || <span class="num">0</span>
+<span class="kw">end</span>
+
+<span class="kw">def</span> <span class="fn">send_alert</span>(msg)
+  <span class="fn">puts</span> <span class="str">"[ALERT] </span>#{msg}<span class="str">"</span>
+<span class="kw">end</span>
+
+portfolio = [<span class="str">"AAPL"</span>, <span class="str">"GOOG"</span>, <span class="str">"TSLA"</span>, <span class="str">"MSFT"</span>]
+
+<span class="mana-str">~"遍历 &lt;portfolio&gt;，调用 fetch_price 拿价格，价格&gt;200 就 send_alert，总和存 &lt;total&gt;"</span>
+<span class="fn">puts</span> total  <span class="cmt"># =&gt; 579.6</span></pre>
+
+    <div class="code-label">Mixed control flow — Ruby structure, LLM decisions</div>
+<pre>player_hp = <span class="num">100</span>
+enemy_hp = <span class="num">80</span>
+inventory = [<span class="str">"sword"</span>, <span class="str">"potion"</span>, <span class="str">"shield"</span>]
+
+<span class="kw">while</span> player_hp &gt; <span class="num">0</span> &amp;&amp; enemy_hp &gt; <span class="num">0</span>
+  <span class="mana-str">~"玩家 HP=&lt;player_hp&gt;，敌人 HP=&lt;enemy_hp&gt;，背包=&lt;inventory&gt;，选行动存 &lt;action&gt;"</span>
+
+  <span class="kw">case</span> action
+  <span class="kw">when</span> <span class="str">"attack"</span> <span class="kw">then</span> enemy_hp -= <span class="fn">rand</span>(<span class="num">15</span>..<span class="num">25</span>)
+  <span class="kw">when</span> <span class="str">"defend"</span> <span class="kw">then</span> <span class="kw">nil</span>
+  <span class="kw">when</span> <span class="str">"use_item"</span>
+    <span class="mana-str">~"从 &lt;inventory&gt; 选一个治疗物品存 &lt;item_name&gt;"</span>
+    inventory.delete(item_name)
+    player_hp += <span class="num">25</span>
+  <span class="kw">end</span>
+<span class="kw">end</span></pre>
+
+    <div class="code-label">Bare strings in .nrb files — no ~ needed</div>
+<pre><span class="cmt"># math.nrb</span>
+numbers = [<span class="num">1</span>, <span class="num">2</span>, <span class="num">3</span>, <span class="num">4</span>, <span class="num">5</span>]
+<span class="mana-str">"算 &lt;numbers&gt; 的平均值存 &lt;result&gt;"</span>
+<span class="fn">puts</span> result</pre>
+  </section>
+
+  <!-- How it works -->
+  <section>
+    <h2>How it works</h2>
+    <p class="lead">Mana uses an effect system — a Fiber-based handler loop with LLM tool-use protocol.</p>
+
+    <div class="steps">
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-text">
+          <strong>Capture</strong><br>
+          <span><code>~"..."</code> calls <code>String#~@</code>, which captures the caller's <code>Binding</code> via <code>binding_of_caller</code></span>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-text">
+          <strong>Parse</strong><br>
+          <span>Engine extracts <code>&lt;var&gt;</code> references and reads existing variables as context</span>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-text">
+          <strong>Execute</strong><br>
+          <span>Prompt + context sent to LLM with tools: <code>read_var</code>, <code>write_var</code>, <code>read_attr</code>, <code>write_attr</code>, <code>call_func</code>, <code>done</code></span>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-text">
+          <strong>Loop</strong><br>
+          <span>LLM responds with tool calls → Mana executes against live Ruby binding → sends results back → repeat until <code>done</code></span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Comparison -->
+  <section>
+    <h2>Mana vs. the rest</h2>
+    <p class="lead">Existing Ruby LLM libraries are API wrappers. Mana is a language extension.</p>
+
+    <div class="comparison">
+      <div>
+        <h3>Typical LLM gem</h3>
+<pre style="border:none;margin:0;background:none;">client = LLM::Client.new
+response = client.chat(
+  "Classify this email: #{email}"
+)
+category = JSON.parse(response)["category"]
+email.category = category</pre>
+      </div>
+      <div style="border-color: var(--accent);">
+        <h3>ruby-mana</h3>
+<pre style="border:none;margin:0;background:none;"><span class="mana-str">~"读 &lt;email&gt; 的 subject 和 body，设 category"</span>
+
+<span class="cmt"># That's it. email.category is set.</span></pre>
+      </div>
+    </div>
+  </section>
+
+  <!-- Research -->
+  <section>
+    <h2>Research</h2>
+    <p class="lead">Mana is inspired by MIT's Nightjar project and the theory of algebraic effects.</p>
+    <p style="color: var(--text-dim); font-size: 0.9rem; line-height: 1.8;">
+      📄 <a href="https://arxiv.org/abs/2512.14805" style="color: var(--accent3);">Sharing State Between Prompts and Programs</a> — the paper that started it all<br>
+      🐍 <a href="https://github.com/psg-mit/nightjarpy" style="color: var(--accent3);">nightjarpy</a> — MIT's Python implementation<br>
+      💎 ruby-mana — the Ruby implementation, with <code>~"..."</code> syntax and Prism AST transforms
+    </p>
+  </section>
+
+  <!-- Footer -->
+  <footer>
+    <p>
+      <a href="https://github.com/carlnoah6/ruby-mana">GitHub</a> ·
+      <a href="https://rubygems.org/gems/ruby-mana">RubyGems</a> ·
+      MIT License
+    </p>
+    <p style="margin-top: 8px;">Ruby 3.3+ · Anthropic Claude</p>
+  </footer>
+</div>
+
+</body>
+</html>

--- a/examples/chatbot.nrb
+++ b/examples/chatbot.nrb
@@ -1,0 +1,24 @@
+# Example: State machine — bare strings drive a conversation (.nrb)
+# Load with: require "mana"; Mana.load("examples/chatbot")
+
+context = { user_name: nil, topic: nil, history: [] }
+state = "greeting"
+
+3.times do |turn|
+  user_input = case turn
+               when 0 then "Hi, I'm Alice"
+               when 1 then "Tell me about Ruby metaprogramming"
+               when 2 then "Thanks, bye!"
+               end
+
+  context[:history] << { role: "user", text: user_input }
+
+  "根据 <context> 和 <state>，处理用户输入 '#{user_input}'。
+   更新 context 的 user_name 和 topic（如果能推断出来）。
+   生成回复存 <reply>，下一个状态存 <next_state>（greeting/chatting/farewell）"
+
+  context[:history] << { role: "bot", text: reply }
+  state = next_state
+
+  puts "[#{state}] Bot: #{reply}"
+end

--- a/examples/codegen.rb
+++ b/examples/codegen.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Example: Code generation — LLM writes Ruby code, Ruby evals it
+require "mana"
+
+# Describe a function in natural language, LLM writes the implementation
+~"写一个 Ruby 方法 fizzbuzz(n)，返回 1 到 n 的 FizzBuzz 数组。代码存 <code>"
+
+eval(code) # rubocop:disable Security/Eval
+puts fizzbuzz(15).inspect
+# => ["1", "2", "Fizz", "4", "Buzz", "Fizz", "7", "8", "Fizz", "Buzz", "11", "Fizz", "13", "14", "FizzBuzz"]
+
+# Generate a data transformation pipeline
+data = [
+  { name: "Alice", age: 30, salary: 80_000 },
+  { name: "Bob", age: 25, salary: 60_000 },
+  { name: "Charlie", age: 35, salary: 120_000 },
+  { name: "Diana", age: 28, salary: 95_000 }
+]
+
+~"看 <data> 的结构，写一段 Ruby 代码存 <transform_code>：筛选 salary > 70000 的人，按 age 排序，返回 name 数组"
+
+result = eval(transform_code) # rubocop:disable Security/Eval
+puts result.inspect
+# => ["Diana", "Alice", "Charlie"]

--- a/examples/data_cleaning.rb
+++ b/examples/data_cleaning.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Example: Data cleaning — LLM normalizes messy real-world data
+require "mana"
+
+raw_contacts = [
+  { name: "john doe", phone: "1234567890", email: "JOHN@GMAIL.COM" },
+  { name: "Jane Smith PhD", phone: "(555) 123-4567", email: "jane.smith@company.co" },
+  { name: "bob", phone: "+1-999-888-7777", email: "BOB123@yahoo" },
+  { name: "María García-López", phone: "N/A", email: "maria@empresa.mx" },
+  { name: "李明", phone: "13800138000", email: "liming@163.com" }
+]
+
+cleaned = []
+
+raw_contacts.each do |contact|
+  ~"清洗这条联系人数据 #{contact.inspect}：
+    - name 标准化为 Title Case（保留非拉丁字符原样）
+    - phone 统一为 +X-XXX-XXX-XXXX 格式（无效的设为 nil）
+    - email 小写化，无效的设为 nil
+    结果存 <clean_name> <clean_phone> <clean_email>"
+
+  cleaned << { name: clean_name, phone: clean_phone, email: clean_email }
+end
+
+cleaned.each do |c|
+  puts "#{c[:name].to_s.ljust(25)} #{(c[:phone] || 'N/A').ljust(18)} #{c[:email] || 'N/A'}"
+end

--- a/examples/research.rb
+++ b/examples/research.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Example: Multi-step reasoning — LLM plans and executes a research task
+require "mana"
+
+def search_db(query)
+  # Simulated database
+  db = {
+    "ruby" => { created: 1995, creator: "Matz", type: "dynamic" },
+    "python" => { created: 1991, creator: "Guido", type: "dynamic" },
+    "rust" => { created: 2010, creator: "Graydon Hoare", type: "static" },
+    "go" => { created: 2009, creator: "Rob Pike et al.", type: "static" }
+  }
+  db[query.downcase]
+end
+
+def calculate(expression)
+  eval(expression).to_f # rubocop:disable Security/Eval
+end
+
+languages = ["Ruby", "Python", "Rust", "Go"]
+
+~"用 search_db 查询 <languages> 里每种语言的信息。
+  用 calculate 算出它们的平均创建年份。
+  按创建时间排序，写一段比较分析存 <analysis>。
+  最老的语言存 <oldest>，最新的存 <newest>"
+
+puts "Oldest: #{oldest}"
+puts "Newest: #{newest}"
+puts "\n#{analysis}"

--- a/examples/sentiment.rb
+++ b/examples/sentiment.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Example: Sentiment analysis on user reviews
+require "mana"
+
+reviews = [
+  "This product is amazing! Best purchase I've ever made.",
+  "Terrible quality. Broke after two days. Want a refund.",
+  "It's okay, nothing special. Does what it says.",
+  "Absolutely love it! Already bought one for my friend.",
+  "Shipping was slow but the product itself is decent."
+]
+
+results = []
+
+reviews.each do |review|
+  ~"分析这条评论的情感: '#{review}'。存 sentiment 为 positive/neutral/negative，confidence 为 0-1 的浮点数"
+  results << { text: review, sentiment: sentiment, confidence: confidence }
+end
+
+results.each do |r|
+  puts "#{r[:sentiment].upcase.ljust(10)} (#{r[:confidence]}) #{r[:text][0..50]}..."
+end
+
+~"根据 <results>，写一段总结存 <summary>"
+puts "\n#{summary}"

--- a/examples/translation.rb
+++ b/examples/translation.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Example: Translation pipeline — LLM as a multilingual processor
+require "mana"
+
+menu_items = [
+  { dish: "宫保鸡丁", price: 38 },
+  { dish: "麻婆豆腐", price: 28 },
+  { dish: "红烧肉", price: 45 },
+  { dish: "清蒸鲈鱼", price: 68 }
+]
+
+translations = {}
+
+menu_items.each do |item|
+  dish = item[:dish]
+  ~"把菜名 '#{dish}' 翻译成英文存 <english>，翻译成日文存 <japanese>，写一句英文描述存 <description>"
+  translations[dish] = { en: english, ja: japanese, desc: description, price: item[:price] }
+end
+
+puts "=" * 70
+puts "MENU / メニュー / 菜单"
+puts "=" * 70
+translations.each do |cn, info|
+  puts "\n#{cn} / #{info[:en]} / #{info[:ja]}"
+  puts "  ¥#{info[:price]} — #{info[:desc]}"
+end


### PR DESCRIPTION
## What's new

### 6 new examples
- **sentiment.rb** — batch sentiment analysis on reviews
- **codegen.rb** — LLM generates Ruby code from natural language descriptions
- **data_cleaning.rb** — normalize messy real-world contact data
- **research.rb** — multi-step reasoning with function calls (search_db + calculate)
- **translation.rb** — multilingual menu translation pipeline (CN → EN/JA)
- **chatbot.nrb** — state machine conversation using bare strings

### Landing page (GitHub Pages)
- Single-page dark-themed site at `docs/index.html`
- Hero with live code example
- Feature grid, comparison table, how-it-works steps
- Links to GitHub, RubyGems, and the research paper
- Auto-deploys via `.github/workflows/pages.yml`

### RubyGems
- Release workflow already in place (from PR #1)
- Just needs `RUBYGEMS_API_KEY` secret + `git tag v0.1.0 && git push --tags`