### PR TITLE
fix: replace remaining CJK text with English

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Embed LLM as native Ruby. Write natural language, it just runs.
 ```ruby
 require "mana"
 
-numbers = [1, "2", "three", "cuatro", "五"]
+numbers = [1, "2", "three", "cuatro", "cinq"]
 ~"compute the semantic average of <numbers> and store in <result>"
 puts result  # => 3.0
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -293,7 +293,7 @@
     <div class="hero-code">
 <pre style="margin:0;border:none;padding:0;background:none;"><span class="kw">require</span> <span class="str">"mana"</span>
 
-numbers = [<span class="num">1</span>, <span class="str">"2"</span>, <span class="str">"three"</span>, <span class="str">"cuatro"</span>, <span class="str">"五"</span>]
+numbers = [<span class="num">1</span>, <span class="str">"2"</span>, <span class="str">"three"</span>, <span class="str">"cuatro"</span>, <span class="str">"cinq"</span>]
 <span class="mana-str">~"compute the semantic average of &lt;numbers&gt; and store in &lt;result&gt;"</span>
 <span class="fn">puts</span> result  <span class="cmt"># =&gt; 3.0</span></pre>
     </div>

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -3,6 +3,6 @@
 # Example: Basic ~"..." usage
 require "mana"
 
-numbers = [1, "2", "three", "cuatro", "五"]
+numbers = [1, "2", "three", "cuatro", "cinq"]
 ~"consider the semantic values of <numbers>, compute their average and store in <result>"
 puts result

--- a/examples/data_cleaning.rb
+++ b/examples/data_cleaning.rb
@@ -8,7 +8,7 @@ raw_contacts = [
   { name: "Jane Smith PhD", phone: "(555) 123-4567", email: "jane.smith@company.co" },
   { name: "bob", phone: "+1-999-888-7777", email: "BOB123@yahoo" },
   { name: "María García-López", phone: "N/A", email: "maria@empresa.mx" },
-  { name: "李明", phone: "13800138000", email: "liming@163.com" }
+  { name: "Li Ming", phone: "13800138000", email: "liming@163.com" }
 ]
 
 cleaned = []

--- a/examples/translation.rb
+++ b/examples/translation.rb
@@ -4,24 +4,24 @@
 require "mana"
 
 menu_items = [
-  { dish: "宫保鸡丁", price: 38 },
-  { dish: "麻婆豆腐", price: 28 },
-  { dish: "红烧肉", price: 45 },
-  { dish: "清蒸鲈鱼", price: 68 }
+  { dish: "Kung Pao Chicken", price: 38 },
+  { dish: "Mapo Tofu", price: 28 },
+  { dish: "Braised Pork Belly", price: 45 },
+  { dish: "Steamed Sea Bass", price: 68 }
 ]
 
 translations = {}
 
 menu_items.each do |item|
   dish = item[:dish]
-  ~"translate the dish name '#{dish}' to English and store in <english>, to Japanese and store in <japanese>, and write a one-line English description in <description>"
-  translations[dish] = { en: english, ja: japanese, desc: description, price: item[:price] }
+  ~"translate the dish name '#{dish}' to French and store in <french>, to Japanese and store in <japanese>, and write a one-line description in <description>"
+  translations[dish] = { fr: french, ja: japanese, desc: description, price: item[:price] }
 end
 
 puts "=" * 70
-puts "MENU / メニュー / 菜单"
+puts "MENU"
 puts "=" * 70
-translations.each do |cn, info|
-  puts "\n#{cn} / #{info[:en]} / #{info[:ja]}"
-  puts "  ¥#{info[:price]} — #{info[:desc]}"
+translations.each do |en, info|
+  puts "\n#{en} / #{info[:fr]} / #{info[:ja]}"
+  puts "  $#{info[:price]} — #{info[:desc]}"
 end


### PR DESCRIPTION
Replace all remaining Chinese/Japanese characters in examples and docs:
- `五` → `cinq` in numbers array (README, basic.rb, landing page)
- `李明` → `Li Ming` in data_cleaning.rb
- Chinese dish names → English in translation.rb
- Removed Japanese menu header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example code snippets and sample data throughout documentation and README.
  * Refreshed examples to demonstrate additional language support and updated sample datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->