### PR TITLE
feat: Mana.session — shared conversation context

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,21 @@ Mana.define_effect :search_web,
 
 Built-in effects (`read_var`, `write_var`, `read_attr`, `write_attr`, `call_func`, `done`) are reserved and cannot be overridden.
 
+### Sessions — shared context
+
+By default each `~"..."` starts fresh. Wrap multiple calls in `Mana.session` to share conversation context:
+
+```ruby
+Mana.session do
+  ~"remember: always translate to Japanese, casual tone"
+  ~"translate <text1>, store in <result1>"   # uses the preference
+  ~"translate <text2>, store in <result2>"   # still remembers
+  ~"which translation was harder? store in <analysis>"  # can reference both
+end
+```
+
+Outside the session block, context resets.
+
 ### LLM-compiled methods
 
 `mana def` lets LLM generate a method implementation on first call. The generated code is cached as a real `.rb` file — subsequent calls are pure Ruby with zero API overhead.

--- a/examples/session.rb
+++ b/examples/session.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Example: Session — shared context across multiple prompts
+require "mana"
+
+text1 = "The quick brown fox jumps over the lazy dog"
+text2 = "To be or not to be, that is the question"
+
+Mana.session do
+  # Set a preference — LLM remembers this
+  ~"remember: always translate to Japanese, use casual tone"
+
+  # First translation — uses the remembered preference
+  ~"translate <text1>, store in <result1>"
+  puts "1: #{result1}"
+
+  # Second translation — still remembers the preference
+  ~"translate <text2>, store in <result2>"
+  puts "2: #{result2}"
+
+  # LLM can reference earlier context
+  ~"which of the two translations was harder? store reason in <analysis>"
+  puts "Analysis: #{analysis}"
+end
+
+# Outside the session — fresh context, no memory
+~"translate <text1> to French, store in <french>"
+puts "French: #{french}"

--- a/lib/mana.rb
+++ b/lib/mana.rb
@@ -3,6 +3,7 @@
 require_relative "mana/version"
 require_relative "mana/config"
 require_relative "mana/effect_registry"
+require_relative "mana/session"
 require_relative "mana/engine"
 require_relative "mana/introspect"
 require_relative "mana/compiler"
@@ -45,6 +46,11 @@ module Mana
     # Remove a custom effect
     def undefine_effect(name)
       EffectRegistry.undefine(name)
+    end
+
+    # Run a block with shared conversation context
+    def session(&block)
+      Session.run(&block)
     end
 
     # View generated source for a mana-compiled method

--- a/lib/mana/session.rb
+++ b/lib/mana/session.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Mana
+  # Session maintains conversation context across multiple ~"..." calls.
+  #
+  # Usage:
+  #   Mana.session do
+  #     ~"remember: user prefers concise style"
+  #     ~"translate <text>"      # remembers the preference
+  #     ~"translate <text2>"     # still remembers
+  #   end
+  #
+  # Without a session, each ~"..." starts fresh with no memory.
+  class Session
+    attr_reader :messages
+
+    def initialize
+      @messages = []
+    end
+
+    class << self
+      # Get the current thread-local session (if any)
+      def current
+        Thread.current[:mana_session]
+      end
+
+      # Run a block within a session scope
+      def run(&block)
+        previous = Thread.current[:mana_session]
+        session = new
+        Thread.current[:mana_session] = session
+        block.call(session)
+      ensure
+        Thread.current[:mana_session] = previous
+      end
+    end
+  end
+end

--- a/spec/mana/session_spec.rb
+++ b/spec/mana/session_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Mana::Session do
+  describe ".current" do
+    it "returns nil outside a session" do
+      expect(described_class.current).to be_nil
+    end
+
+    it "returns the session inside a session block" do
+      described_class.run do |session|
+        expect(described_class.current).to eq(session)
+        expect(described_class.current).to be_a(described_class)
+      end
+    end
+
+    it "restores nil after session ends" do
+      described_class.run { |_| }
+      expect(described_class.current).to be_nil
+    end
+
+    it "restores previous session on nesting" do
+      described_class.run do |outer|
+        described_class.run do |inner|
+          expect(described_class.current).to eq(inner)
+        end
+        expect(described_class.current).to eq(outer)
+      end
+    end
+  end
+
+  describe "#messages" do
+    it "starts with empty messages" do
+      described_class.run do |session|
+        expect(session.messages).to eq([])
+      end
+    end
+
+    it "accumulates messages across engine calls" do
+      Mana.config.api_key = "test-key"
+
+      # First call: LLM writes a var
+      stub_request(:post, "https://api.anthropic.com/v1/messages")
+        .to_return(
+          { status: 200, headers: { "Content-Type" => "application/json" },
+            body: JSON.generate({ content: [
+              { type: "tool_use", id: "t1", name: "done", input: { "result" => "noted" } }
+            ] }) },
+          { status: 200, headers: { "Content-Type" => "application/json" },
+            body: JSON.generate({ content: [
+              { type: "tool_use", id: "t2", name: "done", input: { "result" => "translated" } }
+            ] }) }
+        )
+
+      described_class.run do |session|
+        b = binding
+        Mana::Engine.run("remember: be concise", b)
+
+        # After first call, messages should have user + assistant
+        expect(session.messages.length).to be >= 2
+
+        Mana::Engine.run("translate something", b)
+
+        # After second call, messages should have accumulated
+        expect(session.messages.length).to be >= 4
+      end
+    end
+  end
+
+  describe "Mana.session" do
+    it "delegates to Session.run" do
+      called = false
+      Mana.session do |_session|
+        called = true
+        expect(Mana::Session.current).not_to be_nil
+      end
+      expect(called).to be true
+    end
+  end
+end


### PR DESCRIPTION
## What

`Mana.session` shares LLM conversation context across multiple `~"..."` calls.

```ruby
Mana.session do
  ~"remember: user prefers concise style"
  ~"translate <text>"   # remembers the preference
  ~"translate <text2>"  # still remembers
end
```

## How

- `Session` holds a `messages` array in `Thread.current[:mana_session]`
- `Engine#execute` checks for active session — reuses messages if present, starts fresh if not
- System prompt is rebuilt each call (variables may have changed between calls)
- After each `done`, a summary is appended so LLM has full context for the next call
- Nesting supported: inner session restores outer on exit

## Files
- `lib/mana/session.rb` — Session class with thread-local storage
- `lib/mana/engine.rb` — session-aware message handling
- `spec/mana/session_spec.rb` — 6 tests
- `examples/session.rb` — usage demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `Mana.session` block functionality to maintain shared conversation context across multiple prompts. Context automatically resets when exiting a session, enabling cleaner session management.

* **Documentation**
  * Added documentation explaining shared session context semantics and usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->