### PR TITLE
feat: test mode — Mana.mock + mock_prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,47 @@ Mana.incognito do
 end
 ```
 
+### Testing
+
+Use `Mana.mock` to test code that uses `~"..."` without calling any API:
+
+```ruby
+require "mana/test"
+
+RSpec.describe MyApp do
+  include Mana::TestHelpers
+
+  it "analyzes code" do
+    mock_prompt "analyze", bugs: ["XSS"], score: 8.5
+
+    result = MyApp.analyze("user_input")
+    expect(result[:bugs]).to include("XSS")
+  end
+
+  it "translates with dynamic response" do
+    mock_prompt(/translate.*to\s+\w+/) do |prompt|
+      { output: prompt.include?("Chinese") ? "你好" : "hello" }
+    end
+
+    expect(MyApp.translate("hi", "Chinese")).to eq("你好")
+  end
+end
+```
+
+Block mode for inline tests:
+
+```ruby
+Mana.mock do
+  prompt "summarize", summary: "A brief overview"
+
+  text = "Long article..."
+  ~"summarize <text> and store in <summary>"
+  puts summary  # => "A brief overview"
+end
+```
+
+Unmatched prompts raise `Mana::MockError` with a helpful message suggesting the stub to add.
+
 ### Nested prompts
 
 Functions called by LLM can themselves contain `~"..."` prompts:

--- a/docs/index.html
+++ b/docs/index.html
@@ -171,6 +171,14 @@ lint = ->(<span class="fn">code</span>) { <span class="ms">~"check #{code} for s
 <span class="ms">~"review &lt;codebase&gt;, call lint for each file, store in &lt;report&gt;"</span>
 puts report  <span class="cmt"># each nested call gets its own context</span></pre>
     </div>
+    <div class="slide">
+<pre><span class="cmt"># Test mode — no API calls needed</span>
+<span class="kw">require</span> <span class="str">"mana/test"</span>
+
+mock_prompt <span class="str">"analyze"</span>, bugs: [<span class="str">"XSS"</span>], score: <span class="num">8.5</span>
+mock_prompt(<span class="str">/translate/</span>) { |p| { output: <span class="str">"hola"</span> } }
+<span class="cmt"># ~"..." calls match stubs, never hit the API</span></pre>
+    </div>
     <div class="carousel-dots" id="carouselDots"></div>
   </div>
 
@@ -239,6 +247,10 @@ email.priority = data[<span class="str">"priority"</span>]</pre>
     <div class="card">
       <h3>🪆 Nested prompts</h3>
       <p>Functions called by LLM can themselves use <code>~"..."</code>. Each nested call gets its own conversation context while sharing long-term memory.</p>
+    </div>
+    <div class="card">
+      <h3>🧪 Test mode</h3>
+      <p>Stub LLM responses with <code>mock_prompt</code>. String or regex matching, block-based dynamic values. Zero API calls in tests.</p>
     </div>
   </div>
 </section>
@@ -330,6 +342,23 @@ Mana.memory.forget(id: <span class="num">1</span>)      <span class="cmt"># remo
 <span class="cmt"># Incognito mode — clean slate</span>
 Mana.incognito <span class="kw">do</span>
   <span class="ms">~"translate &lt;text3&gt;"</span>           <span class="cmt"># no memory loaded or saved</span>
+<span class="kw">end</span></pre>
+  </div>
+
+  <div class="ex">
+    <h3>Testing — mock mode</h3>
+    <p>Stub LLM responses by pattern. No API key or network needed in tests.</p>
+<pre><span class="kw">require</span> <span class="str">"mana/test"</span>
+
+RSpec.describe MyApp <span class="kw">do</span>
+  include Mana::TestHelpers
+
+  it <span class="str">"analyzes code"</span> <span class="kw">do</span>
+    mock_prompt <span class="str">"analyze"</span>, bugs: [<span class="str">"XSS"</span>], score: <span class="num">8.5</span>
+
+    result = MyApp.analyze(<span class="str">"input"</span>)
+    expect(result[:bugs]).to include(<span class="str">"XSS"</span>)
+  <span class="kw">end</span>
 <span class="kw">end</span></pre>
   </div>
 

--- a/lib/mana.rb
+++ b/lib/mana.rb
@@ -17,6 +17,7 @@ module Mana
   class Error < StandardError; end
   class MaxIterationsError < Error; end
   class LLMError < Error; end
+  class MockError < Error; end
 
   class << self
     def config
@@ -40,6 +41,7 @@ module Mana
       @config = Config.new
       EffectRegistry.clear!
       Thread.current[:mana_memory] = nil
+      Thread.current[:mana_mock] = nil
     end
 
     # Define a custom effect that becomes an LLM tool
@@ -73,3 +75,5 @@ module Mana
     end
   end
 end
+
+require_relative "mana/mock"

--- a/lib/mana/mock.rb
+++ b/lib/mana/mock.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Mana
+  class Mock
+    Stub = Struct.new(:pattern, :values, :block, keyword_init: true)
+
+    attr_reader :stubs
+
+    def initialize
+      @stubs = []
+    end
+
+    def prompt(pattern, **values, &block)
+      @stubs << Stub.new(pattern: pattern, values: values, block: block)
+    end
+
+    def match(prompt_text)
+      @stubs.find do |stub|
+        case stub.pattern
+        when Regexp then prompt_text.match?(stub.pattern)
+        when String then prompt_text.include?(stub.pattern)
+        end
+      end
+    end
+  end
+
+  class << self
+    def mock(&block)
+      old_mock = Thread.current[:mana_mock]
+      m = Mock.new
+      Thread.current[:mana_mock] = m
+      m.instance_eval(&block)
+    ensure
+      Thread.current[:mana_mock] = old_mock
+    end
+
+    def mock!
+      Thread.current[:mana_mock] = Mock.new
+    end
+
+    def unmock!
+      Thread.current[:mana_mock] = nil
+    end
+
+    def mock_active?
+      !Thread.current[:mana_mock].nil?
+    end
+
+    def current_mock
+      Thread.current[:mana_mock]
+    end
+  end
+end

--- a/lib/mana/test.rb
+++ b/lib/mana/test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "mana"
+
+module Mana
+  module TestHelpers
+    def self.included(base)
+      base.before { Mana.mock! }
+      base.after { Mana.unmock! }
+    end
+
+    def mock_prompt(pattern, **values, &block)
+      raise Mana::MockError, "Mana mock mode not active. Call Mana.mock! first" unless Mana.mock_active?
+
+      Mana.current_mock.prompt(pattern, **values, &block)
+    end
+  end
+end

--- a/spec/mana/mock_spec.rb
+++ b/spec/mana/mock_spec.rb
@@ -1,0 +1,338 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "mana/test"
+
+RSpec.describe Mana::Mock do
+  before do
+    Mana.config.api_key = "test-key"
+    Thread.current[:mana_memory] = nil
+    Thread.current[:mana_incognito] = nil
+    Thread.current[:mana_mock] = nil
+    @tmpdir = Dir.mktmpdir("mana_test")
+    Mana.config.memory_store = Mana::FileStore.new(@tmpdir)
+  end
+
+  after do
+    Thread.current[:mana_memory] = nil
+    Thread.current[:mana_incognito] = nil
+    Thread.current[:mana_mock] = nil
+    FileUtils.rm_rf(@tmpdir)
+    Mana.reset!
+  end
+
+  describe "Mana.mock (block mode)" do
+    it "sets variables via stub values" do
+      result_bugs = nil
+      result_score = nil
+
+      Mana.mock do
+        prompt "analyze", bugs: ["XSS"], score: 8.5
+
+        b = binding
+        Mana::Engine.run("analyze <code> for issues", b)
+        result_bugs = b.local_variable_get(:bugs)
+        result_score = b.local_variable_get(:score)
+      end
+
+      expect(result_bugs).to eq(["XSS"])
+      expect(result_score).to eq(8.5)
+    end
+
+    it "returns _return value from stub" do
+      result = nil
+
+      Mana.mock do
+        prompt "translate", _return: "hello"
+
+        b = binding
+        result = Mana::Engine.run("translate this text", b)
+      end
+
+      expect(result).to eq("hello")
+    end
+
+    it "returns first value when no _return specified" do
+      result = nil
+
+      Mana.mock do
+        prompt "analyze", score: 9.0
+
+        b = binding
+        result = Mana::Engine.run("analyze this", b)
+      end
+
+      expect(result).to eq(9.0)
+    end
+
+    it "matches with substring" do
+      output = nil
+
+      Mana.mock do
+        prompt "translate", output: "hola"
+
+        b = binding
+        Mana::Engine.run("please translate <text> to Spanish", b)
+        output = b.local_variable_get(:output)
+      end
+
+      expect(output).to eq("hola")
+    end
+
+    it "matches with regex" do
+      output = nil
+
+      Mana.mock do
+        prompt(/translate.*Spanish/i, output: "hola")
+
+        b = binding
+        Mana::Engine.run("translate <text> to Spanish please", b)
+        output = b.local_variable_get(:output)
+      end
+
+      expect(output).to eq("hola")
+    end
+
+    it "supports block-based dynamic values" do
+      output = nil
+
+      Mana.mock do
+        prompt("translate") do |prompt_text|
+          if prompt_text.include?("Spanish")
+            { output: "hola" }
+          else
+            { output: "hello" }
+          end
+        end
+
+        b = binding
+        Mana::Engine.run("translate to Spanish", b)
+        output = b.local_variable_get(:output)
+      end
+
+      expect(output).to eq("hola")
+    end
+
+    it "raises MockError for unmatched prompts" do
+      expect {
+        Mana.mock do
+          prompt "translate", output: "hi"
+
+          b = binding
+          Mana::Engine.run("unrelated prompt about weather", b)
+        end
+      }.to raise_error(Mana::MockError, /No mock matched/)
+    end
+
+    it "includes helpful message in MockError" do
+      expect {
+        Mana.mock do
+          b = binding
+          Mana::Engine.run("analyze code", b)
+        end
+      }.to raise_error(Mana::MockError, /mock_prompt/)
+    end
+
+    it "cleans up mock mode after block" do
+      Mana.mock do
+        prompt "test", result: "ok"
+      end
+
+      expect(Mana.mock_active?).to be false
+    end
+
+    it "cleans up mock mode even on error" do
+      begin
+        Mana.mock do
+          raise "boom"
+        end
+      rescue RuntimeError
+        # expected
+      end
+
+      expect(Mana.mock_active?).to be false
+    end
+
+    it "does not make any API calls" do
+      Mana.mock do
+        prompt "compute", result: 42
+
+        b = binding
+        Mana::Engine.run("compute something", b)
+      end
+
+      expect(WebMock).not_to have_requested(:post, "https://api.anthropic.com/v1/messages")
+    end
+
+    it "matches first matching stub" do
+      result = nil
+
+      Mana.mock do
+        prompt "analyze", result: "first"
+        prompt "analyze code", result: "second"
+
+        b = binding
+        result = Mana::Engine.run("analyze code", b)
+      end
+
+      expect(result).to eq("first")
+    end
+  end
+
+  describe "Mana.mock! / Mana.unmock!" do
+    it "activates and deactivates mock mode" do
+      expect(Mana.mock_active?).to be false
+
+      Mana.mock!
+      expect(Mana.mock_active?).to be true
+
+      Mana.unmock!
+      expect(Mana.mock_active?).to be false
+    end
+
+    it "allows registering stubs via current_mock" do
+      Mana.mock!
+      Mana.current_mock.prompt("test", value: 42)
+
+      b = binding
+      Mana::Engine.run("test this", b)
+      expect(b.local_variable_get(:value)).to eq(42)
+
+      Mana.unmock!
+    end
+  end
+
+  describe "thread safety" do
+    it "mock mode is thread-local" do
+      Mana.mock!
+      Mana.current_mock.prompt("test", value: 1)
+
+      other_thread_mock = nil
+      t = Thread.new { other_thread_mock = Mana.mock_active? }
+      t.join
+
+      expect(Mana.mock_active?).to be true
+      expect(other_thread_mock).to be false
+
+      Mana.unmock!
+    end
+  end
+
+  describe "memory interaction" do
+    it "records mock interactions in short-term memory" do
+      Mana.mock!
+      Mana.current_mock.prompt("test", value: 42)
+
+      b = binding
+      Mana::Engine.run("test prompt", b)
+
+      memory = Mana.memory
+      expect(memory.short_term.size).to eq(2)
+      expect(memory.short_term[0][:role]).to eq("user")
+      expect(memory.short_term[0][:content]).to eq("test prompt")
+      expect(memory.short_term[1][:role]).to eq("assistant")
+
+      Mana.unmock!
+    end
+
+    it "skips memory in incognito mode" do
+      Mana::Memory.incognito do
+        Mana.mock!
+        Mana.current_mock.prompt("test", value: 42)
+
+        b = binding
+        Mana::Engine.run("test prompt", b)
+
+        Mana.unmock!
+      end
+
+      memory = Mana.memory
+      expect(memory.short_term).to be_empty
+    end
+  end
+
+  describe "Mana.reset!" do
+    it "clears mock state" do
+      Mana.mock!
+      expect(Mana.mock_active?).to be true
+
+      Mana.reset!
+      expect(Mana.mock_active?).to be false
+    end
+  end
+end
+
+RSpec.describe Mana::TestHelpers do
+  before do
+    Mana.config.api_key = "test-key"
+    Thread.current[:mana_memory] = nil
+    Thread.current[:mana_incognito] = nil
+    Thread.current[:mana_mock] = nil
+    @tmpdir = Dir.mktmpdir("mana_test")
+    Mana.config.memory_store = Mana::FileStore.new(@tmpdir)
+  end
+
+  after do
+    Thread.current[:mana_memory] = nil
+    Thread.current[:mana_incognito] = nil
+    Thread.current[:mana_mock] = nil
+    FileUtils.rm_rf(@tmpdir)
+    Mana.reset!
+  end
+
+  describe "mock_prompt helper" do
+    it "raises when mock mode is not active" do
+      helper = Object.new
+      helper.extend(Mana::TestHelpers)
+
+      expect {
+        helper.mock_prompt("test", value: 1)
+      }.to raise_error(Mana::MockError, /mock mode not active/)
+    end
+
+    it "registers stubs when mock is active" do
+      helper = Object.new
+      helper.extend(Mana::TestHelpers)
+
+      Mana.mock!
+      helper.mock_prompt("analyze", bugs: ["SQL injection"], score: 7.0)
+
+      b = binding
+      Mana::Engine.run("analyze this code", b)
+      expect(b.local_variable_get(:bugs)).to eq(["SQL injection"])
+      expect(b.local_variable_get(:score)).to eq(7.0)
+
+      Mana.unmock!
+    end
+
+    it "supports regex patterns" do
+      helper = Object.new
+      helper.extend(Mana::TestHelpers)
+
+      Mana.mock!
+      helper.mock_prompt(/translate.*to\s+(\w+)/, output: "bonjour")
+
+      b = binding
+      Mana::Engine.run("translate hello to French", b)
+      expect(b.local_variable_get(:output)).to eq("bonjour")
+
+      Mana.unmock!
+    end
+
+    it "supports block-based responses" do
+      helper = Object.new
+      helper.extend(Mana::TestHelpers)
+
+      Mana.mock!
+      helper.mock_prompt("compute") do |prompt_text|
+        { result: prompt_text.include?("sum") ? 10 : 0 }
+      end
+
+      b = binding
+      Mana::Engine.run("compute the sum", b)
+      expect(b.local_variable_get(:result)).to eq(10)
+
+      Mana.unmock!
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Mana.mock { }` block mode and `Mana.mock!`/`Mana.unmock!` for stubbing LLM responses in tests
- Add `Mana::TestHelpers` module with `mock_prompt` helper for RSpec/Minitest integration
- Support string substring matching, regex matching, and block-based dynamic responses
- Unmatched prompts raise `Mana::MockError` with a helpful message suggesting the stub to add
- Mock mode is thread-local and records interactions in short-term memory
- Zero API calls during mock mode — tests run fast and offline

## Test plan
- [x] `Mana.mock { }` block mode sets variables, returns values, cleans up
- [x] String and regex pattern matching
- [x] Block-based dynamic stub responses
- [x] `_return` value controls return from `~"..."`
- [x] Unmatched prompts raise `MockError` with helpful message
- [x] `Mana.mock!`/`Mana.unmock!` for RSpec before/after flow
- [x] `mock_prompt` helper via `Mana::TestHelpers`
- [x] Thread-local isolation (thread safety)
- [x] Memory interactions recorded in short-term memory
- [x] Incognito mode skips memory in mock mode
- [x] `Mana.reset!` clears mock state
- [x] No API calls made during mock mode
- [x] All 179 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced testing/mocking capability for code that uses prompts, enabling tests without API calls.
  * Mocking supports stubbed responses via patterns (string/regex matching) and dynamic blocks.
  * Helpful error messages guide users when prompts don't match configured stubs.

* **Documentation**
  * Added testing guide with mock usage examples and best practices.

* **Tests**
  * Comprehensive test suite covering mock functionality, thread safety, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->