### PR TITLE
feat: multi-LLM backend — Anthropic + OpenAI-compatible APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ Or in your Gemfile:
 gem "ruby-mana"
 ```
 
-Requires Ruby 3.3+ and an Anthropic API key:
+Requires Ruby 3.3+ and an API key (Anthropic, OpenAI, or compatible):
 
 ```bash
 export ANTHROPIC_API_KEY=your_key_here
+# or
+export OPENAI_API_KEY=your_key_here
 ```
 
 ## Usage
@@ -145,6 +147,41 @@ Mana.configure do |c|
   c.memory_store = Mana::FileStore.new  # default file-based persistence
 end
 ```
+
+### Multiple LLM backends
+
+Mana supports Anthropic and OpenAI-compatible APIs (including Ollama, DeepSeek, Groq, etc.):
+
+```ruby
+# Anthropic (default for claude-* models)
+Mana.configure do |c|
+  c.api_key = ENV["ANTHROPIC_API_KEY"]
+  c.model = "claude-sonnet-4-20250514"
+end
+
+# OpenAI
+Mana.configure do |c|
+  c.api_key = ENV["OPENAI_API_KEY"]
+  c.base_url = "https://api.openai.com"
+  c.model = "gpt-4o"
+end
+
+# Ollama (local, no API key needed)
+Mana.configure do |c|
+  c.api_key = "unused"
+  c.base_url = "http://localhost:11434"
+  c.model = "llama3"
+end
+
+# Explicit backend override
+Mana.configure do |c|
+  c.backend = :openai  # force OpenAI format
+  c.base_url = "https://api.groq.com/openai"
+  c.model = "llama-3.3-70b-versatile"
+end
+```
+
+Backend is auto-detected from model name: `claude-*` → Anthropic, everything else → OpenAI.
 
 ### Custom effect handlers
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -119,7 +119,7 @@
   <p class="sub"><em>Not an API wrapper.</em> A language construct that weaves LLM into your code.</p>
   <div class="badges">
     <span class="badge">Ruby 3.3+</span>
-    <span class="badge">Anthropic Claude</span>
+    <span class="badge">Multi-LLM</span>
     <span class="badge">MIT License</span>
   </div>
 
@@ -178,6 +178,15 @@ puts report  <span class="cmt"># each nested call gets its own context</span></p
 mock_prompt <span class="str">"analyze"</span>, bugs: [<span class="str">"XSS"</span>], score: <span class="num">8.5</span>
 mock_prompt(<span class="str">/translate/</span>) { |p| { output: <span class="str">"hola"</span> } }
 <span class="cmt"># ~"..." calls match stubs, never hit the API</span></pre>
+    </div>
+    <div class="slide">
+<pre><span class="cmt"># Multi-LLM — Anthropic, OpenAI, Ollama, and more</span>
+Mana.configure <span class="kw">do</span> |c|
+  c.api_key = ENV[<span class="str">"OPENAI_API_KEY"</span>]
+  c.base_url = <span class="str">"https://api.openai.com"</span>
+  c.model = <span class="str">"gpt-4o"</span>
+<span class="kw">end</span>
+<span class="cmt"># auto-detects backend from model name</span></pre>
     </div>
     <div class="carousel-dots" id="carouselDots"></div>
   </div>
@@ -251,6 +260,10 @@ email.priority = data[<span class="str">"priority"</span>]</pre>
     <div class="card">
       <h3>🧪 Test mode</h3>
       <p>Stub LLM responses with <code>mock_prompt</code>. String or regex matching, block-based dynamic values. Zero API calls in tests.</p>
+    </div>
+    <div class="card">
+      <h3>🔌 Multi-LLM backends</h3>
+      <p>Anthropic and OpenAI-compatible APIs out of the box. Works with Ollama, DeepSeek, Groq, and more. Auto-detects backend from model name.</p>
     </div>
   </div>
 </section>
@@ -412,7 +425,7 @@ puts email.priority  <span class="cmt"># =&gt; "critical"</span></pre>
   <h2>Install</h2>
   <div class="ib"><code><span class="d">$ </span>gem install ruby-mana</code></div>
   <p style="color:var(--dim);font-size:.9rem;margin-bottom:8px">Or in your Gemfile: <code>gem "ruby-mana"</code></p>
-  <p style="color:var(--dim);font-size:.9rem">Requires Ruby 3.3+ and <code>ANTHROPIC_API_KEY</code> environment variable.</p>
+  <p style="color:var(--dim);font-size:.9rem">Requires Ruby 3.3+ and an API key (<code>ANTHROPIC_API_KEY</code> or <code>OPENAI_API_KEY</code>).</p>
 </section>
 
 <!-- Research -->

--- a/lib/mana.rb
+++ b/lib/mana.rb
@@ -2,6 +2,10 @@
 
 require_relative "mana/version"
 require_relative "mana/config"
+require_relative "mana/backends/base"
+require_relative "mana/backends/anthropic"
+require_relative "mana/backends/openai"
+require_relative "mana/backends/registry"
 require_relative "mana/effect_registry"
 require_relative "mana/namespace"
 require_relative "mana/memory_store"

--- a/lib/mana/backends/anthropic.rb
+++ b/lib/mana/backends/anthropic.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+
+module Mana
+  module Backends
+    class Anthropic < Base
+      def chat(system:, messages:, tools:, model:, max_tokens: 4096)
+        uri = URI("#{@config.base_url}/v1/messages")
+        body = {
+          model: model,
+          max_tokens: max_tokens,
+          system: system,
+          tools: tools,
+          messages: messages
+        }
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        http.read_timeout = 120
+
+        req = Net::HTTP::Post.new(uri)
+        req["Content-Type"] = "application/json"
+        req["x-api-key"] = @config.api_key
+        req["anthropic-version"] = "2023-06-01"
+        req.body = JSON.generate(body)
+
+        res = http.request(req)
+        raise LLMError, "HTTP #{res.code}: #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+
+        parsed = JSON.parse(res.body, symbolize_names: true)
+        parsed[:content] || []
+      end
+    end
+  end
+end

--- a/lib/mana/backends/base.rb
+++ b/lib/mana/backends/base.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mana
+  module Backends
+    class Base
+      def initialize(config)
+        @config = config
+      end
+
+      # Send a chat request, return array of content blocks in Anthropic format
+      # (normalized). Each backend converts its native response to this format.
+      # Returns: [{ type: "text", text: "..." }, { type: "tool_use", id: "...", name: "...", input: {...} }]
+      def chat(system:, messages:, tools:, model:, max_tokens: 4096)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/mana/backends/openai.rb
+++ b/lib/mana/backends/openai.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+
+module Mana
+  module Backends
+    class OpenAI < Base
+      def chat(system:, messages:, tools:, model:, max_tokens: 4096)
+        uri = URI("#{@config.base_url}/v1/chat/completions")
+        body = {
+          model: model,
+          max_completion_tokens: max_tokens,
+          messages: convert_messages(system, messages),
+          tools: convert_tools(tools)
+        }
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        http.read_timeout = 120
+
+        req = Net::HTTP::Post.new(uri)
+        req["Content-Type"] = "application/json"
+        req["Authorization"] = "Bearer #{@config.api_key}"
+        req.body = JSON.generate(body)
+
+        res = http.request(req)
+        raise LLMError, "HTTP #{res.code}: #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+
+        parsed = JSON.parse(res.body, symbolize_names: true)
+        normalize_response(parsed)
+      end
+
+      private
+
+      # Convert Anthropic-style messages to OpenAI format
+      def convert_messages(system, messages)
+        result = [{ role: "system", content: system }]
+
+        messages.each do |msg|
+          case msg[:role]
+          when "user"
+            converted = convert_user_message(msg)
+            if converted.is_a?(Array)
+              result.concat(converted)
+            else
+              result << converted
+            end
+          when "assistant"
+            result << convert_assistant_message(msg)
+          end
+        end
+
+        result
+      end
+
+      def convert_user_message(msg)
+        content = msg[:content]
+
+        # Plain text user message
+        return { role: "user", content: content } if content.is_a?(String)
+
+        # Array of content blocks — may contain tool_result blocks
+        if content.is_a?(Array) && content.all? { |b| b[:type] == "tool_result" || b["type"] == "tool_result" }
+          # Convert each tool_result to an OpenAI tool message
+          return content.map do |block|
+            {
+              role: "tool",
+              tool_call_id: block[:tool_use_id] || block["tool_use_id"],
+              content: (block[:content] || block["content"]).to_s
+            }
+          end
+        end
+
+        # Other array content (e.g. text blocks) — join as string
+        if content.is_a?(Array)
+          texts = content.map { |b| b[:text] || b["text"] }.compact
+          return { role: "user", content: texts.join("\n") }
+        end
+
+        { role: "user", content: content.to_s }
+      end
+
+      def convert_assistant_message(msg)
+        content = msg[:content]
+
+        # Simple text response
+        if content.is_a?(String)
+          return { role: "assistant", content: content }
+        end
+
+        # Array of content blocks — may contain tool_use
+        if content.is_a?(Array)
+          text_parts = []
+          tool_calls = []
+
+          content.each do |block|
+            type = block[:type] || block["type"]
+            case type
+            when "text"
+              text_parts << (block[:text] || block["text"])
+            when "tool_use"
+              tool_calls << {
+                id: block[:id] || block["id"],
+                type: "function",
+                function: {
+                  name: block[:name] || block["name"],
+                  arguments: JSON.generate(block[:input] || block["input"] || {})
+                }
+              }
+            end
+          end
+
+          msg_hash = { role: "assistant" }
+          msg_hash[:content] = text_parts.join("\n") unless text_parts.empty?
+          msg_hash[:tool_calls] = tool_calls unless tool_calls.empty?
+          return msg_hash
+        end
+
+        { role: "assistant", content: content.to_s }
+      end
+
+      # Convert Anthropic tool definitions to OpenAI function calling format
+      def convert_tools(tools)
+        tools.map do |tool|
+          {
+            type: "function",
+            function: {
+              name: tool[:name],
+              description: tool[:description] || "",
+              parameters: tool[:input_schema] || {}
+            }
+          }
+        end
+      end
+
+      # Convert OpenAI response back to Anthropic-style content blocks
+      def normalize_response(parsed)
+        choice = parsed.dig(:choices, 0, :message)
+        return [] unless choice
+
+        blocks = []
+
+        # Text content
+        if choice[:content] && !choice[:content].empty?
+          blocks << { type: "text", text: choice[:content] }
+        end
+
+        # Tool calls
+        if choice[:tool_calls]
+          choice[:tool_calls].each do |tc|
+            func = tc[:function]
+            blocks << {
+              type: "tool_use",
+              id: tc[:id],
+              name: func[:name],
+              input: JSON.parse(func[:arguments], symbolize_names: true)
+            }
+          end
+        end
+
+        blocks
+      end
+    end
+  end
+end

--- a/lib/mana/backends/registry.rb
+++ b/lib/mana/backends/registry.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Mana
+  module Backends
+    ANTHROPIC_PATTERNS = /^(claude-)/i
+    OPENAI_PATTERNS = /^(gpt-|o1-|o3-|chatgpt-|dall-e|tts-|whisper-)/i
+
+    def self.for(config)
+      return config.backend if config.backend.is_a?(Base)
+
+      case config.backend&.to_s
+      when "openai" then OpenAI.new(config)
+      when "anthropic" then Anthropic.new(config)
+      else
+        # Auto-detect from model name
+        case config.model
+        when ANTHROPIC_PATTERNS then Anthropic.new(config)
+        else OpenAI.new(config) # Default to OpenAI (most compatible)
+        end
+      end
+    end
+  end
+end

--- a/lib/mana/config.rb
+++ b/lib/mana/config.rb
@@ -3,6 +3,7 @@
 module Mana
   class Config
     attr_accessor :model, :temperature, :api_key, :max_iterations, :base_url,
+                  :backend,
                   :namespace, :memory_store, :memory_path,
                   :context_window, :memory_pressure, :memory_keep_recent,
                   :compact_model, :on_compact
@@ -13,6 +14,7 @@ module Mana
       @api_key = ENV["ANTHROPIC_API_KEY"]
       @max_iterations = 50
       @base_url = "https://api.anthropic.com"
+      @backend = nil
       @namespace = nil
       @memory_store = nil
       @memory_path = nil

--- a/spec/mana/backends/anthropic_spec.rb
+++ b/spec/mana/backends/anthropic_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Mana::Backends::Anthropic do
+  let(:config) do
+    Mana::Config.new.tap do |c|
+      c.api_key = "test-anthropic-key"
+      c.base_url = "https://api.anthropic.com"
+      c.model = "claude-sonnet-4-20250514"
+    end
+  end
+
+  let(:backend) { described_class.new(config) }
+
+  let(:tools) do
+    [{ name: "done", description: "Signal done", input_schema: { type: "object", properties: {} } }]
+  end
+
+  describe "#chat" do
+    it "sends correct auth headers" do
+      stub = stub_request(:post, "https://api.anthropic.com/v1/messages")
+        .with(
+          headers: {
+            "x-api-key" => "test-anthropic-key",
+            "anthropic-version" => "2023-06-01",
+            "Content-Type" => "application/json"
+          }
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({ content: [{ type: "text", text: "hello" }] })
+        )
+
+      backend.chat(system: "sys", messages: [], tools: tools, model: "claude-sonnet-4-20250514")
+      expect(stub).to have_been_requested
+    end
+
+    it "sends request body in Anthropic format" do
+      stub_request(:post, "https://api.anthropic.com/v1/messages")
+        .with { |req|
+          body = JSON.parse(req.body)
+          body["model"] == "claude-sonnet-4-20250514" &&
+            body["max_tokens"] == 4096 &&
+            body["system"] == "You are helpful." &&
+            body["tools"].is_a?(Array) &&
+            body["messages"] == [{ "role" => "user", "content" => "hi" }]
+        }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({ content: [] })
+        )
+
+      backend.chat(
+        system: "You are helpful.",
+        messages: [{ role: "user", content: "hi" }],
+        tools: tools,
+        model: "claude-sonnet-4-20250514"
+      )
+    end
+
+    it "returns content blocks from response" do
+      stub_request(:post, "https://api.anthropic.com/v1/messages")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({
+            content: [
+              { type: "text", text: "thinking..." },
+              { type: "tool_use", id: "t1", name: "done", input: { result: "ok" } }
+            ]
+          })
+        )
+
+      result = backend.chat(system: "sys", messages: [], tools: tools, model: "claude-sonnet-4-20250514")
+      expect(result.size).to eq(2)
+      expect(result[0][:type]).to eq("text")
+      expect(result[1][:type]).to eq("tool_use")
+      expect(result[1][:name]).to eq("done")
+    end
+
+    it "returns empty array when content is nil" do
+      stub_request(:post, "https://api.anthropic.com/v1/messages")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({})
+        )
+
+      result = backend.chat(system: "sys", messages: [], tools: tools, model: "claude-sonnet-4-20250514")
+      expect(result).to eq([])
+    end
+
+    it "raises LLMError on HTTP error" do
+      stub_request(:post, "https://api.anthropic.com/v1/messages")
+        .to_return(status: 500, body: "Internal Server Error")
+
+      expect {
+        backend.chat(system: "sys", messages: [], tools: tools, model: "claude-sonnet-4-20250514")
+      }.to raise_error(Mana::LLMError, /HTTP 500/)
+    end
+
+    it "uses custom base_url" do
+      config.base_url = "https://custom-proxy.example.com"
+      stub = stub_request(:post, "https://custom-proxy.example.com/v1/messages")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({ content: [] })
+        )
+
+      backend.chat(system: "sys", messages: [], tools: tools, model: "claude-sonnet-4-20250514")
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/mana/backends/openai_spec.rb
+++ b/spec/mana/backends/openai_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Mana::Backends::OpenAI do
+  let(:config) do
+    Mana::Config.new.tap do |c|
+      c.api_key = "test-openai-key"
+      c.base_url = "https://api.openai.com"
+      c.model = "gpt-4o"
+    end
+  end
+
+  let(:backend) { described_class.new(config) }
+
+  let(:tools) do
+    [
+      {
+        name: "write_var",
+        description: "Write a variable",
+        input_schema: {
+          type: "object",
+          properties: { name: { type: "string" }, value: {} },
+          required: %w[name value]
+        }
+      },
+      {
+        name: "done",
+        description: "Signal done",
+        input_schema: { type: "object", properties: { result: {} } }
+      }
+    ]
+  end
+
+  describe "#chat" do
+    it "sends correct auth headers" do
+      stub = stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .with(
+          headers: {
+            "Authorization" => "Bearer test-openai-key",
+            "Content-Type" => "application/json"
+          }
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({ choices: [{ message: { content: "hi" } }] })
+        )
+
+      backend.chat(system: "sys", messages: [], tools: tools, model: "gpt-4o")
+      expect(stub).to have_been_requested
+    end
+
+    it "converts system prompt to system message" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .with { |req|
+          body = JSON.parse(req.body)
+          body["messages"][0] == { "role" => "system", "content" => "You are helpful." }
+        }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({ choices: [{ message: { content: "ok" } }] })
+        )
+
+      backend.chat(
+        system: "You are helpful.",
+        messages: [{ role: "user", content: "hi" }],
+        tools: tools,
+        model: "gpt-4o"
+      )
+    end
+
+    it "converts tool definitions to OpenAI function format" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .with { |req|
+          body = JSON.parse(req.body)
+          t = body["tools"][0]
+          t["type"] == "function" &&
+            t["function"]["name"] == "write_var" &&
+            t["function"]["parameters"]["type"] == "object"
+        }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({ choices: [{ message: { content: "ok" } }] })
+        )
+
+      backend.chat(system: "sys", messages: [], tools: tools, model: "gpt-4o")
+    end
+
+    it "converts tool_result messages to OpenAI tool role" do
+      messages = [
+        { role: "user", content: "do something" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "call_123", name: "write_var", input: { name: "x", value: 1 } }
+          ]
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "call_123", content: "ok: x = 1" }
+          ]
+        }
+      ]
+
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .with { |req|
+          body = JSON.parse(req.body)
+          msgs = body["messages"]
+          # system + user + assistant (with tool_calls) + tool
+          msgs.length == 4 &&
+            msgs[2]["role"] == "assistant" &&
+            msgs[2]["tool_calls"][0]["function"]["name"] == "write_var" &&
+            msgs[3]["role"] == "tool" &&
+            msgs[3]["tool_call_id"] == "call_123"
+        }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({ choices: [{ message: { content: "done" } }] })
+        )
+
+      backend.chat(system: "sys", messages: messages, tools: tools, model: "gpt-4o")
+    end
+
+    it "normalizes text response to Anthropic format" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({
+            choices: [{ message: { role: "assistant", content: "Hello!" } }]
+          })
+        )
+
+      result = backend.chat(system: "sys", messages: [], tools: tools, model: "gpt-4o")
+      expect(result).to eq([{ type: "text", text: "Hello!" }])
+    end
+
+    it "normalizes tool_calls response to Anthropic content blocks" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({
+            choices: [{
+              message: {
+                role: "assistant",
+                content: nil,
+                tool_calls: [
+                  {
+                    id: "call_abc",
+                    type: "function",
+                    function: {
+                      name: "write_var",
+                      arguments: '{"name":"result","value":42}'
+                    }
+                  }
+                ]
+              }
+            }]
+          })
+        )
+
+      result = backend.chat(system: "sys", messages: [], tools: tools, model: "gpt-4o")
+      expect(result.size).to eq(1)
+      expect(result[0][:type]).to eq("tool_use")
+      expect(result[0][:id]).to eq("call_abc")
+      expect(result[0][:name]).to eq("write_var")
+      expect(result[0][:input]).to eq({ name: "result", value: 42 })
+    end
+
+    it "normalizes response with both text and tool_calls" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({
+            choices: [{
+              message: {
+                role: "assistant",
+                content: "Let me help",
+                tool_calls: [
+                  {
+                    id: "call_xyz",
+                    type: "function",
+                    function: { name: "done", arguments: '{"result":"ok"}' }
+                  }
+                ]
+              }
+            }]
+          })
+        )
+
+      result = backend.chat(system: "sys", messages: [], tools: tools, model: "gpt-4o")
+      expect(result.size).to eq(2)
+      expect(result[0]).to eq({ type: "text", text: "Let me help" })
+      expect(result[1][:type]).to eq("tool_use")
+      expect(result[1][:name]).to eq("done")
+    end
+
+    it "returns empty array when no choices" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({ choices: [] })
+        )
+
+      result = backend.chat(system: "sys", messages: [], tools: tools, model: "gpt-4o")
+      expect(result).to eq([])
+    end
+
+    it "raises LLMError on HTTP error" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .to_return(status: 429, body: "Rate limited")
+
+      expect {
+        backend.chat(system: "sys", messages: [], tools: tools, model: "gpt-4o")
+      }.to raise_error(Mana::LLMError, /HTTP 429/)
+    end
+
+    it "uses custom base_url for compatible APIs" do
+      config.base_url = "http://localhost:11434"
+      stub = stub_request(:post, "http://localhost:11434/v1/chat/completions")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: JSON.generate({ choices: [{ message: { content: "ok" } }] })
+        )
+
+      backend.chat(system: "sys", messages: [], tools: tools, model: "llama3")
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/mana/backends/registry_spec.rb
+++ b/spec/mana/backends/registry_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Mana::Backends do
+  describe ".for" do
+    it "returns Anthropic backend for claude-* models" do
+      config = Mana::Config.new
+      config.model = "claude-sonnet-4-20250514"
+      expect(described_class.for(config)).to be_a(Mana::Backends::Anthropic)
+    end
+
+    it "returns Anthropic backend for claude-3 models" do
+      config = Mana::Config.new
+      config.model = "claude-3-haiku-20240307"
+      expect(described_class.for(config)).to be_a(Mana::Backends::Anthropic)
+    end
+
+    it "returns OpenAI backend for gpt-* models" do
+      config = Mana::Config.new
+      config.model = "gpt-4o"
+      expect(described_class.for(config)).to be_a(Mana::Backends::OpenAI)
+    end
+
+    it "returns OpenAI backend for o1-* models" do
+      config = Mana::Config.new
+      config.model = "o1-preview"
+      expect(described_class.for(config)).to be_a(Mana::Backends::OpenAI)
+    end
+
+    it "returns OpenAI backend for o3-* models" do
+      config = Mana::Config.new
+      config.model = "o3-mini"
+      expect(described_class.for(config)).to be_a(Mana::Backends::OpenAI)
+    end
+
+    it "defaults to OpenAI for unknown models" do
+      config = Mana::Config.new
+      config.model = "llama3"
+      expect(described_class.for(config)).to be_a(Mana::Backends::OpenAI)
+    end
+
+    it "defaults to OpenAI for deepseek models" do
+      config = Mana::Config.new
+      config.model = "deepseek-chat"
+      expect(described_class.for(config)).to be_a(Mana::Backends::OpenAI)
+    end
+
+    it "respects explicit :anthropic backend setting" do
+      config = Mana::Config.new
+      config.backend = :anthropic
+      config.model = "gpt-4o" # would normally auto-detect as OpenAI
+      expect(described_class.for(config)).to be_a(Mana::Backends::Anthropic)
+    end
+
+    it "respects explicit :openai backend setting" do
+      config = Mana::Config.new
+      config.backend = :openai
+      config.model = "claude-sonnet-4-20250514" # would normally auto-detect as Anthropic
+      expect(described_class.for(config)).to be_a(Mana::Backends::OpenAI)
+    end
+
+    it "respects explicit string 'openai' backend setting" do
+      config = Mana::Config.new
+      config.backend = "openai"
+      config.model = "llama-3.3-70b-versatile"
+      expect(described_class.for(config)).to be_a(Mana::Backends::OpenAI)
+    end
+
+    it "returns a Backend instance directly if provided" do
+      config = Mana::Config.new
+      custom_backend = Mana::Backends::Anthropic.new(config)
+      config.backend = custom_backend
+      expect(described_class.for(config)).to equal(custom_backend)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Extract the hardcoded Anthropic HTTP call from `engine.rb` into a pluggable backend abstraction (`Backends::Base`, `Backends::Anthropic`, `Backends::OpenAI`)
- Add `Backends.for(config)` registry that auto-detects which backend to use from model name (`claude-*` → Anthropic, everything else → OpenAI)
- OpenAI backend handles the full tool calling round-trip: converts Mana's Anthropic-style messages/tools to OpenAI format, and normalizes responses back — supporting Ollama, DeepSeek, Groq, and any OpenAI-compatible API
- Add `config.backend` for explicit override (`:anthropic`, `:openai`, or a `Backend` instance)

## Files changed
- **New:** `lib/mana/backends/base.rb`, `anthropic.rb`, `openai.rb`, `registry.rb`
- **Modified:** `lib/mana/engine.rb` — replaced inline `Net::HTTP` with `Backends.for(@config).chat(...)`
- **Modified:** `lib/mana/config.rb` — added `backend` attribute
- **Modified:** `lib/mana.rb` — added backend requires
- **New:** `spec/mana/backends/anthropic_spec.rb`, `openai_spec.rb`, `registry_spec.rb`
- **Modified:** `README.md`, `docs/index.html` — multi-backend documentation

## Test plan
- [x] All 206 existing tests pass (no breaking changes)
- [x] New backend specs cover: auth headers, request format, response normalization, tool calling round-trip, error handling, custom base URLs
- [x] Registry specs cover: auto-detection for claude-*, gpt-*, o1-*, o3-*, unknown models, explicit override, instance passthrough
- [ ] Manual test with OpenAI API key and `gpt-4o` model
- [ ] Manual test with Ollama local server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-LLM backend support: now compatible with OpenAI, Anthropic, Ollama, DeepSeek, Groq, and other compatible APIs.
  * Implemented automatic backend detection based on model name (e.g., claude-* uses Anthropic, gpt-* uses OpenAI).
  * Added explicit backend configuration option for flexible provider selection.

* **Documentation**
  * Updated installation and configuration guides to reflect multi-backend support.
  * Added examples for configuring each LLM provider and backend auto-detection behavior.

* **Tests**
  * Added comprehensive test coverage for all supported backends and selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->