### PR TITLE
refactor: replace three capability flags with execution_engine?

### DIFF
--- a/lib/mana/engines/base.rb
+++ b/lib/mana/engines/base.rb
@@ -13,19 +13,29 @@ module Mana
       # --- Capability queries ---
       # Subclasses override to declare what they support.
 
-      # Can this engine hold remote references to objects in other engines?
-      def supports_remote_ref?
+      # Is this an execution engine (Ruby/JS/Python) or a reasoning engine (LLM)?
+      # Execution engines can execute code, hold state, and be called bidirectionally.
+      # Reasoning engines process natural language but cannot hold references or state.
+      def execution_engine?
         true
+      end
+
+      # Can this engine hold remote references to objects in other engines?
+      # Derived from execution_engine? — only execution engines support remote refs.
+      def supports_remote_ref?
+        execution_engine?
       end
 
       # Can code in this engine call back into another engine (bidirectional)?
+      # Derived from execution_engine? — only execution engines support bidirectional calls.
       def supports_bidirectional?
-        true
+        execution_engine?
       end
 
       # Does this engine maintain mutable state across calls?
+      # Derived from execution_engine? — only execution engines maintain state.
       def supports_state?
-        true
+        execution_engine?
       end
 
       # Execute code/prompt in this engine, return the result

--- a/lib/mana/engines/llm.rb
+++ b/lib/mana/engines/llm.rb
@@ -5,18 +5,11 @@ require "json"
 module Mana
   module Engines
     class LLM < Base
-      # LLM is a special engine: it understands natural language and uses
-      # tool-calling to interact with Ruby variables, but it cannot hold
-      # remote object references or be called back from other engines.
-      def supports_remote_ref?
-        false
-      end
-
-      def supports_bidirectional?
-        false
-      end
-
-      def supports_state?
+      # LLM is a reasoning engine, not an execution engine.
+      # It understands natural language and uses tool-calling to interact with
+      # Ruby variables, but it cannot hold remote object references, maintain
+      # state, or be called back from other engines.
+      def execution_engine?
         false
       end
 


### PR DESCRIPTION
## Summary
Replace three redundant capability flags with a single `execution_engine?` method.

## Problem
The three capability flags (`supports_remote_ref?`, `supports_bidirectional?`, `supports_state?`) were always identical:
- Ruby/JS/Python: all `true`
- LLM: all `false`

This indicates they describe the same underlying property, not independent capabilities.

## Solution
- Add `execution_engine?` as the single source of truth
  - `true` for Ruby/JS/Python (execution engines)
  - `false` for LLM (reasoning engine)
- Derive the three old methods from `execution_engine?` (backward compatible)

## Benefits
- Clearer semantics: execution vs reasoning engines
- Less redundancy: one method instead of three
- Future-proof: easy to add new engine categories if needed

## Testing
All 439 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated engine architecture to use a unified capability detection mechanism, consolidating how different engine types identify themselves and their supported features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->