### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.1] - 2026-02-24
+
+### Changed
+- **Engine capability refactor** — replaced three redundant capability flags (`supports_remote_ref?`, `supports_bidirectional?`, `supports_state?`) with a single `execution_engine?` method
+- Clearer semantics: execution engines (Ruby/JS/Python) vs reasoning engines (LLM)
+- Fully backward compatible — old methods still work as derived properties
+
 ## [0.5.0] - 2026-02-22
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-mana (0.5.0)
+    ruby-mana (0.5.1)
       binding_of_caller (~> 1.0)
       mini_racer (~> 0.16)
 

--- a/lib/mana/version.rb
+++ b/lib/mana/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mana
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
## Release v0.5.1

### Changes
- Engine capability refactor — replaced three redundant flags with `execution_engine?`
- Fully backward compatible
- All 439 tests pass

### Checklist
- [x] Version bumped to 0.5.1
- [x] CHANGELOG updated
- [x] Gemfile.lock updated
- [ ] Merge to main
- [ ] Tag v0.5.1
- [ ] Push to RubyGems
- [ ] Update website

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 0.5.1

* **Changed**
  * Refined execution engine capability detection mechanisms with improved semantic clarity
  * Simplified interface for identifying engine types and capabilities
  * Full backward compatibility maintained—existing implementations require no changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->