### PR TITLE
fix: use correct OAuth token field in Claude Code Action

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "Bash,Read,Write,Edit,Glob,Grep"
           max_turns: 20


### PR DESCRIPTION
fix anthropic_api_key → claude_code_oauth_token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **杂项 (Chores)**
  * 更新了内部工作流配置，无用户端影响

<!-- end of auto-generated comment: release notes by coderabbit.ai -->