### PR TITLE
Four immediate robustness fixes (compiler/knowledge logging, tool error contract, Open3)

### DIFF
--- a/lib/mana/compiler.rb
+++ b/lib/mana/compiler.rb
@@ -67,7 +67,11 @@ module Mana
             .reject { |m| m[:name] == method_name.to_s }
             .map { |m| "#{m[:name]}(#{m[:params].join(',')})" }
             .sort.join(";")
-        rescue
+        rescue => e
+          # Sibling-introspection failure shouldn't break compilation, but
+          # silently swallowing it hides real bugs (e.g. Introspect API drift,
+          # unreadable source files). Surface under verbose mode.
+          $stderr.puts "[mana compiler] sibling introspection failed for #{source_file}: #{e.class}: #{e.message}" if Mana.config.verbose
           ""
         end
         prompt_hash = Digest::SHA256.hexdigest("#{Mana::VERSION}:#{RUBY_VERSION}:#{method_name}:#{params_desc}:#{prompt}:#{sibling_methods}")[0, 16]
@@ -239,7 +243,11 @@ module Mana
           end
         end
         nil
-      rescue
+      rescue => e
+        # iseq layout can change across Ruby versions; failure here just means
+        # we couldn't extract the literal string — caller falls back gracefully.
+        # Log under verbose so version-related regressions are findable.
+        $stderr.puts "[mana compiler] iseq string extraction failed: #{e.class}: #{e.message}" if Mana.config.verbose
         nil
       end
 

--- a/lib/mana/knowledge.rb
+++ b/lib/mana/knowledge.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "shellwords"
+require "open3"
 
 module Mana
   # Runtime knowledge base — assembles information about ruby-mana from live code.
@@ -38,16 +39,34 @@ module Mana
       # Query Ruby's ri documentation tool (runs outside bundler to access rdoc).
       # Must escape bundler env because ri needs access to system-wide rdoc files
       # that bundler's isolated gem path would hide.
+      #
+      # Uses Open3.capture3 with array args instead of backticks: no shell
+      # parsing means no chance of metacharacter injection (even though
+      # shellescape was already mitigating it), stdout/stderr are separated,
+      # and we can log the actual reason when ri fails.
       def query_ri(topic)
-        output = if defined?(Bundler)
-          Bundler.with_unbundled_env { `ri --format=markdown #{topic.shellescape} 2>&1` }
+        cmd = ["ri", "--format=markdown", topic.to_s]
+        stdout, stderr, status = if defined?(Bundler)
+          Bundler.with_unbundled_env { Open3.capture3(*cmd) }
         else
-          `ri --format=markdown #{topic.shellescape} 2>&1`
+          Open3.capture3(*cmd)
         end
-        return nil unless $?.success?
+
+        unless status.success?
+          if Mana.config.verbose
+            $stderr.puts "[mana knowledge] ri #{topic.inspect} failed (exit #{status.exitstatus}): #{stderr.strip[0, 200]}"
+          end
+          return nil
+        end
+
         # Truncate long docs to avoid flooding the LLM's context window
-        output.length > 3000 ? "#{output[0, 3000]}\n\n... (truncated, #{output.length} chars total)" : output
-      rescue
+        stdout.length > 3000 ? "#{stdout[0, 3000]}\n\n... (truncated, #{stdout.length} chars total)" : stdout
+      rescue Errno::ENOENT => e
+        # ri itself isn't installed — common in slim CI images. Worth knowing.
+        $stderr.puts "[mana knowledge] ri command not found: #{e.message}" if Mana.config.verbose
+        nil
+      rescue => e
+        $stderr.puts "[mana knowledge] ri query failed: #{e.class}: #{e.message}" if Mana.config.verbose
         nil
       end
 

--- a/lib/mana/tool_handler.rb
+++ b/lib/mana/tool_handler.rb
@@ -8,10 +8,33 @@ module Mana
   # which can access @binding, @written_vars, etc.
   # External tools (registered via Mana.register_tool) are dispatched via Procs
   # that only receive input — they cannot access the engine's binding.
+  #
+  # === Return value contract
+  #
+  # Tool handlers return a String that gets sent back to the LLM as the
+  # tool_result content. The convention:
+  #
+  #   "ok: ..."     — successful mutation (write_var, write_attr)
+  #   "error: ..."  — recoverable failure; the LLM sees this and can adjust
+  #   <other str>   — query result (the value, JSON, or rendered text)
+  #
+  # For unrecoverable failures (the "error" tool, or anything the engine
+  # should stop on), raise Mana::LLMError instead of returning a string —
+  # handle_effect re-raises it so the outer loop terminates cleanly.
   module ToolHandler
     BUILTIN_TOOLS = %w[read_var write_var read_attr write_attr call_func eval knowledge done error].freeze
 
+    # Standardized prefixes — keep in sync with the contract above.
+    TOOL_ERROR_PREFIX = "error: "
+    TOOL_OK_PREFIX    = "ok: "
+
     private
+
+    # Format a recoverable tool error consistently. Use this anywhere a
+    # handler wants to report a failure back to the LLM.
+    def tool_error(message)
+      "#{TOOL_ERROR_PREFIX}#{message}"
+    end
 
     # Dispatch a single tool call from the LLM.
     def handle_effect(tool_use)
@@ -25,7 +48,7 @@ module Mana
       elsif (handler = Mana.tool_handlers[name])
         handler.call(input)
       else
-        "error: unknown tool #{name}"
+        tool_error("unknown tool #{name}")
       end
     rescue LLMError
       # LLMError must propagate to the caller (e.g. from the error tool)
@@ -33,7 +56,7 @@ module Mana
     rescue ScriptError, StandardError => e
       # ScriptError covers SyntaxError, LoadError, NotImplementedError
       # StandardError covers everything else (NameError, TypeError, etc.)
-      "error: #{e.class}: #{e.message}"
+      tool_error("#{e.class}: #{e.message}")
     end
 
     # --- Built-in tool handlers ---

--- a/spec/mana/knowledge_spec.rb
+++ b/spec/mana/knowledge_spec.rb
@@ -61,6 +61,38 @@ RSpec.describe Mana::Knowledge do
       end
     end
 
+    context "ri failure logging" do
+      # Regression: query_ri used to `rescue nil` silently. Now under verbose
+      # mode it logs the actual reason so users can diagnose missing ri.
+
+      it "logs to stderr when ri exits non-zero (verbose mode)" do
+        Mana.config.verbose = true
+        # Open3.capture3 returns [stdout, stderr, status] — stub a failed run
+        failed_status = double("status", success?: false, exitstatus: 1)
+        allow(Open3).to receive(:capture3).and_return(["", "ri: nothing known", failed_status])
+        expect { described_class.send(:query_ri, "NoSuchClass") }
+          .to output(/\[mana knowledge\] ri.*nothing known/).to_stderr
+      ensure
+        Mana.config.verbose = false
+      end
+
+      it "logs to stderr when ri command is not installed (verbose mode)" do
+        Mana.config.verbose = true
+        allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT, "ri")
+        expect { described_class.send(:query_ri, "Array") }
+          .to output(/ri command not found/).to_stderr
+      ensure
+        Mana.config.verbose = false
+      end
+
+      it "stays silent in non-verbose mode" do
+        Mana.config.verbose = false
+        failed_status = double("status", success?: false, exitstatus: 1)
+        allow(Open3).to receive(:capture3).and_return(["", "ri: nothing known", failed_status])
+        expect { described_class.send(:query_ri, "NoSuchClass") }.not_to output.to_stderr
+      end
+    end
+
     context "runtime introspection fallback" do
       it "returns introspection when ri has no result" do
         # Use a class that ri might not document but Ruby knows about

--- a/spec/mana/tool_handler_spec.rb
+++ b/spec/mana/tool_handler_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# ToolHandler is mixed into Engine. We instantiate Engine to exercise it.
+RSpec.describe Mana::ToolHandler do
+  let(:bind) { Object.new.instance_eval { x = 1; binding } }
+  let(:engine) { Mana::Engine.new(bind) }
+
+  describe "error return contract" do
+    it "uses the standardized 'error: ' prefix for unknown tools" do
+      result = engine.send(:handle_effect, { name: "nonexistent_tool_xyz", input: {} })
+      expect(result).to start_with(Mana::ToolHandler::TOOL_ERROR_PREFIX)
+      expect(result).to include("unknown tool")
+    end
+
+    it "uses the standardized 'error: ' prefix when a handler raises" do
+      # write_var with a binding that doesn't allow that var name → raises
+      # internally, gets caught and stringified.
+      result = engine.send(:handle_effect, {
+        name: "call_func",
+        input: { "name" => "absolutely_no_such_method_anywhere" }
+      })
+      expect(result).to start_with(Mana::ToolHandler::TOOL_ERROR_PREFIX)
+      expect(result).to include("NameError")
+    end
+
+    it "propagates LLMError from the 'error' tool (does not stringify)" do
+      expect {
+        engine.send(:handle_effect, { name: "error", input: { "message" => "boom" } })
+      }.to raise_error(Mana::LLMError, "boom")
+    end
+
+    it "uses the standardized 'ok: ' prefix for write_var success" do
+      engine.instance_variable_set(:@written_vars, {})
+      result = engine.send(:handle_effect, {
+        name: "write_var",
+        input: { "name" => "x", "value" => 42 }
+      })
+      expect(result).to start_with(Mana::ToolHandler::TOOL_OK_PREFIX)
+    end
+  end
+
+  describe ".tool_error helper" do
+    it "formats messages with the canonical prefix" do
+      expect(engine.send(:tool_error, "bad input")).to eq("error: bad input")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Four small, independent fixes surfaced by an internal audit:

1. **Compiler bare-rescue logging** — \`lib/mana/compiler.rb\` had two \`rescue\` blocks (sibling-method introspection, iseq string extraction) that silently swallowed exceptions. Now they log under \`Mana.config.verbose\` so version drift / API breakage is findable.
2. **Open3 + array args** — replace \`\`\`ri --format=markdown #{topic.shellescape}\`\`\` backticks with \`Open3.capture3("ri", ...)\`. Cleaner, splits stdout/stderr, distinguishes "ri exits non-zero" from "ri not installed". (\`shellescape\` was already preventing injection; this is observability + cleanliness, not new security.)
3. **Tool error format contract** — extract \`TOOL_ERROR_PREFIX\`/\`TOOL_OK_PREFIX\` constants, add a \`tool_error(msg)\` helper, document the string-return-value contract at the module level. Stops the prefix from drifting in future changes.
4. **(same as #2)** — \`Knowledge.query_ri\` no longer hides ri failures under bare \`rescue nil\`; each failure mode logs its own reason.

8 new tests covering ri stderr logging, tool error contract, and LLMError propagation from the \`error\` tool.

## Test plan

- [x] \`bundle exec rspec\` — 373 examples, 0 failures (was 365, +8 new)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)