### PR TITLE
Decompose Engine#execute + cover handle_effect/validate_name! edges

### DIFF
--- a/lib/mana/engine.rb
+++ b/lib/mana/engine.rb
@@ -151,6 +151,14 @@ module Mana
 
     # Main execution loop: build context, call LLM, handle tool calls, iterate until done.
     # Optional &on_text block receives streaming text deltas for real-time display.
+    #
+    # The body used to be a single 143-line method. It is split into focused
+    # helpers so each piece is small enough to read and test:
+    #   sanitize_trailing_tool_use!  — repair messages from a prior interrupted call
+    #   run_tool_loop                — the actual while loop (LLM call + tool dispatch)
+    #   compute_return_value         — collapse @written_vars / done_result into a return
+    # The nested-context push/pop + the rollback-on-failure handling stay here
+    # because they own the method-level rescue/ensure flow.
     def execute(prompt, &on_text)
       # Track nesting depth to isolate context for nested ~"..." calls
       Thread.current[:mana_depth] ||= 0
@@ -170,22 +178,12 @@ module Mana
 
       memory = Context.current
       messages = memory.messages
-
-      # Strip trailing unpaired tool_use messages from prior calls.
-      # Both Anthropic and OpenAI reject requests where the last assistant message
-      # has tool_use blocks without corresponding tool_result responses.
-      while messages.last && messages.last[:role] == "assistant" &&
-            messages.last[:content].is_a?(Array) &&
-            messages.last[:content].any? { |b| (b[:type] || b["type"]) == "tool_use" }
-        messages.pop
-      end
+      sanitize_trailing_tool_use!(messages)
 
       # Track where we started in messages — rollback on failure
       messages_start_size = messages.size
       messages << { role: "user", content: prompt }
 
-      iterations = 0
-      done_result = nil
       @written_vars = {}  # Track write_var calls for return value
       @_steps = []        # Trace data: per-iteration usage + timing + tool calls
 
@@ -193,7 +191,58 @@ module Mana
       vlog("🚀 Prompt: #{prompt}")
       vlog("📡 Backend: #{@config.effective_base_url} / #{@config.model}")
 
-      # --- Main tool-calling loop ---
+      done_result, iterations = run_tool_loop(system_prompt, messages, &on_text)
+
+      # Append a final assistant summary so LLM has full context next call
+      if done_result
+        messages << { role: "assistant", content: [{ type: "text", text: "Done: #{done_result}" }] }
+      end
+
+      # Build trace data for external consumers (e.g. Claw::Trace)
+      @trace_data = {
+        prompt: prompt,
+        model: @config.model,
+        steps: @_steps,
+        total_iterations: iterations,
+        timestamp: Time.now.iso8601
+      }
+
+      compute_return_value(done_result)
+    rescue => e
+      # Rollback: remove messages added during this failed call so they don't
+      # pollute short-term memory for subsequent prompts
+      if messages.size > messages_start_size
+        messages.slice!(messages_start_size..)
+      end
+      raise e
+    ensure
+      # Restore outer context when exiting a nested call
+      if nested
+        Thread.current[:mana_context] = outer_context
+      end
+      Thread.current[:mana_depth] -= 1 if Thread.current[:mana_depth]
+    end
+
+    private
+
+    # Strip trailing unpaired tool_use messages from prior interrupted calls.
+    # Both Anthropic and OpenAI reject requests where the last assistant
+    # message has tool_use blocks without corresponding tool_result responses.
+    # Mutates the messages array in place.
+    def sanitize_trailing_tool_use!(messages)
+      while messages.last && messages.last[:role] == "assistant" &&
+            messages.last[:content].is_a?(Array) &&
+            messages.last[:content].any? { |b| (b[:type] || b["type"]) == "tool_use" }
+        messages.pop
+      end
+    end
+
+    # The core tool-calling loop. Returns [done_result, iteration_count].
+    # Mutates messages (appends assistant/user turns) and @_steps (trace).
+    def run_tool_loop(system_prompt, messages, &on_text)
+      iterations = 0
+      done_result = nil
+
       loop do
         iterations += 1
         @_iteration = iterations
@@ -255,23 +304,13 @@ module Mana
         break if tool_uses.any? { |t| t[:name] == "done" }
       end
 
-      # Append a final assistant summary so LLM has full context next call
-      if done_result
-        messages << { role: "assistant", content: [{ type: "text", text: "Done: #{done_result}" }] }
-      end
+      [done_result, iterations]
+    end
 
-      # Build trace data for external consumers (e.g. Claw::Trace)
-      @trace_data = {
-        prompt: prompt,
-        model: @config.model,
-        steps: @_steps,
-        total_iterations: iterations,
-        timestamp: Time.now.iso8601
-      }
-
-      # Return written variables so Ruby 4.0+ users can capture them:
-      #   result = ~"compute average and store in <result>"
-      # Single write -> return the value directly; multiple -> return Hash.
+    # Collapse the engine's outputs into a single Ruby return value:
+    # Single write_var → that value; multiple → Hash; otherwise → done_result.
+    # Ruby 4.0+ users use this to capture results: `result = ~"…"`.
+    def compute_return_value(done_result)
       if @written_vars.size == 1
         @written_vars.values.first
       elsif @written_vars.size > 1
@@ -280,20 +319,9 @@ module Mana
         # No writes — return the done() result
         done_result
       end
-    rescue => e
-      # Rollback: remove messages added during this failed call so they don't
-      # pollute short-term memory for subsequent prompts
-      if messages.size > messages_start_size
-        messages.slice!(messages_start_size..)
-      end
-      raise e
-    ensure
-      # Restore outer context when exiting a nested call
-      if nested
-        Thread.current[:mana_context] = outer_context
-      end
-      Thread.current[:mana_depth] -= 1 if Thread.current[:mana_depth]
     end
+
+    public
 
     # Mock handling — finds a matching stub and writes its values into the caller's binding.
     def handle_mock(prompt)

--- a/spec/mana/medium_batch_spec.rb
+++ b/spec/mana/medium_batch_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Coverage for the medium-batch fixes:
+# - handle_effect error path branches
+# - binding_helpers with unusual identifier shapes
+
+RSpec.describe "Mana::ToolHandler#handle_effect error paths" do
+  let(:bind) { Object.new.instance_eval { x = 1; binding } }
+  let(:engine) { Mana::Engine.new(bind) }
+
+  it "stringifies a NameError from a registered tool handler" do
+    Mana.register_tool({ name: "bad_tool", description: "", input_schema: {} }) do |_|
+      raise NameError, "this is unusable"
+    end
+    result = engine.send(:handle_effect, { name: "bad_tool", input: {} })
+    expect(result).to start_with("error: ")
+    expect(result).to include("NameError")
+    expect(result).to include("unusable")
+  end
+
+  it "stringifies a SyntaxError raised from inside a tool" do
+    result = engine.send(:handle_effect, {
+      name: "eval", input: { "code" => "def end" }
+    })
+    expect(result).to start_with("error: ")
+    expect(result).to include("SyntaxError")
+  end
+
+  it "stringifies a NoMethodError (e.g. from chained call_func on nil)" do
+    bind.local_variable_set(:y, nil)
+    result = engine.send(:handle_effect, {
+      name: "call_func", input: { "name" => "y.upcase" }
+    })
+    expect(result).to start_with("error: ")
+  end
+
+  it "stringifies TypeError" do
+    result = engine.send(:handle_effect, {
+      name: "eval", input: { "code" => "1 + 'a'" }
+    })
+    expect(result).to start_with("error: ")
+    expect(result).to include("TypeError")
+  end
+
+  it "uses the standardized 'error: ' prefix for all string error returns" do
+    # Documents the contract: every recoverable failure returns a string
+    # starting with "error: " so claw's chat-history rendering can detect
+    # tool errors uniformly. The immediate-batch PR factors this into a
+    # TOOL_ERROR_PREFIX constant; this test stays loose to also pass before
+    # that PR lands.
+    bad_inputs = [
+      { name: "nonexistent_tool", input: {} },
+      { name: "eval", input: { "code" => "definitely_not_defined_var_xyz" } },
+      { name: "call_func", input: { "name" => "no_such_method_zzz" } }
+    ]
+    bad_inputs.each do |tool_use|
+      result = engine.send(:handle_effect, tool_use)
+      expect(result).to start_with("error: "),
+        "Expected '#{tool_use[:name]}' error to start with 'error: ', got: #{result.inspect}"
+    end
+  end
+
+  it "does not stringify Mana::LLMError (re-raises for engine loop termination)" do
+    expect {
+      engine.send(:handle_effect, {
+        name: "error", input: { "message" => "stop the loop" }
+      })
+    }.to raise_error(Mana::LLMError, "stop the loop")
+  end
+end
+
+RSpec.describe "Mana::BindingHelpers identifier edge cases" do
+  let(:engine) do
+    b = Object.new.instance_eval { binding }
+    Mana::Engine.new(b)
+  end
+
+  describe "#validate_name!" do
+    it "accepts normal Ruby identifiers" do
+      %w[foo snake_case with_digits1 _internal CamelCase].each do |ok|
+        expect { engine.send(:validate_name!, ok) }.not_to raise_error,
+          "expected #{ok.inspect} to be accepted"
+      end
+    end
+
+    # The regex `\A[A-Za-z_][A-Za-z0-9_]*\z` deliberately rejects shell
+    # metacharacters, predicate/bang suffixes, whitespace, and non-ASCII
+    # letters. Document the actual contract here so future relaxations are
+    # intentional rather than accidental.
+    it "rejects names with shell metacharacters" do
+      ["foo;bar", "foo|bar", "foo`bar`", "foo$(x)", "foo&&bar"].each do |bad|
+        expect { engine.send(:validate_name!, bad) }
+          .to raise_error(Mana::Error),
+          "expected #{bad.inspect} to be rejected"
+      end
+    end
+
+    it "rejects names with whitespace" do
+      ["foo bar", " foo", "foo\n", "foo\t"].each do |bad|
+        expect { engine.send(:validate_name!, bad) }.to raise_error(Mana::Error)
+      end
+    end
+
+    it "rejects empty input" do
+      expect { engine.send(:validate_name!, "") }.to raise_error(Mana::Error)
+    end
+
+    it "rejects predicate/bang suffixes (current regex is conservative)" do
+      # If we ever relax this, the test forces a deliberate decision.
+      expect { engine.send(:validate_name!, "empty?") }.to raise_error(Mana::Error)
+      expect { engine.send(:validate_name!, "save!") }.to raise_error(Mana::Error)
+    end
+
+    it "rejects non-ASCII letters" do
+      # Ruby itself allows unicode identifiers, but our validator restricts
+      # to ASCII so attackers can't slip homograph attacks past.
+      expect { engine.send(:validate_name!, "résumé") }.to raise_error(Mana::Error)
+    end
+  end
+
+  describe "#resolve" do
+    it "handles names with leading underscore" do
+      b = Object.new.instance_eval { _internal = 5; binding }
+      e = Mana::Engine.new(b)
+      expect(e.send(:resolve, "_internal")).to eq(5)
+    end
+
+    it "raises for nonexistent identifiers (not silent nil)" do
+      expect { engine.send(:resolve, "self_not_a_var_xyz") }.to raise_error(NameError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two related cleanups in ruby-mana:

1. **Engine#execute decomposition** — the body was 143 lines doing setup, message sanitation, the LLM/tool loop, trace assembly, return-value computation, rollback, and ensure cleanup together. Split into three focused private helpers:
   - \`sanitize_trailing_tool_use!(messages)\` — repair unpaired tool_use from prior interrupted runs
   - \`run_tool_loop(system_prompt, messages, &on_text)\` — the actual while loop
   - \`compute_return_value(done_result)\` — collapse @written_vars into Ruby return

   \`execute\` now reads top-to-bottom in ~30 lines.

2. **Test coverage for handle_effect + validate_name!** — 14 new tests:
   - \`handle_effect\` consistently stringifies NameError, SyntaxError, NoMethodError, TypeError with the \`error:\` prefix
   - \`handle_effect\` re-raises \`Mana::LLMError\` (does NOT stringify — required for engine-loop termination)
   - \`validate_name!\` contract: accepts ASCII identifiers; rejects shell metacharacters, whitespace, empty, predicate/bang suffixes, and non-ASCII letters

## Test plan

- [x] \`bundle exec rspec\` — 379 examples, 0 failures (was 365, +14 new)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)